### PR TITLE
fix-issue-61-consistency in summary tables output

### DIFF
--- a/modules/local/collect_featurecounts.nf
+++ b/modules/local/collect_featurecounts.nf
@@ -54,7 +54,7 @@ process COLLECT_FEATURECOUNTS {
         ) %>%
         tidyr::unnest(d) %>%
         select(-f) %>%
-        write_tsv("${prefix}_counts.tsv.gz")
+        write_tsv("magmap.${prefix}_counts.tsv.gz")
 
         writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")), paste0("    dplyr: ", packageVersion('dplyr')),
             paste0("    dtplyr: ", packageVersion('dtplyr')), paste0("    data.table: ", packageVersion('data.table')) ), "versions.yml")

--- a/modules/local/collect_featurecounts.nf
+++ b/modules/local/collect_featurecounts.nf
@@ -54,7 +54,7 @@ process COLLECT_FEATURECOUNTS {
         ) %>%
         tidyr::unnest(d) %>%
         select(-f) %>%
-        write_tsv("magmap.${prefix}_counts.tsv.gz")
+        write_tsv("magmap.${prefix}.counts.tsv.gz")
 
         writeLines(c("\\"${task.process}\\":", paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")), paste0("    dplyr: ", packageVersion('dplyr')),
             paste0("    dtplyr: ", packageVersion('dtplyr')), paste0("    data.table: ", packageVersion('data.table')) ), "versions.yml")

--- a/modules/local/prokkagff2tsv.nf
+++ b/modules/local/prokkagff2tsv.nf
@@ -44,7 +44,7 @@ process PROKKAGFF2TSV {
         relocate(sort(colnames(.)[8:ncol(.)]), .after = 7) %>%
         relocate(orf) %>%
         as.data.table() %>%
-        write_tsv("${prefix}.prokka-annotations.tsv.gz")
+        write_tsv("magmap.${prefix}.prokka-annotations.tsv.gz")
 
     writeLines(
         c(

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -508,7 +508,7 @@ workflow MAGMAP {
 
         ch_header
             .concat( ch_metadata )
-            .collectFile(name: "summary_table.taxonomy.tsv",
+            .collectFile(name: "magmap.summary_table.taxonomy.tsv",
             newLine: true,
             storeDir: "${params.outdir}/summary_tables")
     }


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

I changed the main output from summary_tables folder so they all start with "magmap". see issue #61 

I didn't change the documentation as there is a branch open for that and I will change it there.