### PR TITLE
More unused output removed and made them optional

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -41,7 +41,7 @@ process {
         ]
     }
 
-    withName: FIRST_CAT {
+    withName: 'FIRST_CAT' {
         publishDir = [
             enabled: false
         ]
@@ -51,7 +51,20 @@ process {
         publishDir = [
             path: { "${params.outdir}/concatenate" },
             mode: 'copy',
-            pattern: '*.gz'
+            pattern: '*.gz',
+            enabled: params.save_genomes_cat
+        ]
+    }
+
+    withName: GENOMEINDEX {
+        publishDir = [
+            enabled: params.save_genomes_cat
+        ]
+    }
+
+    withName: GINDEX_CAT {
+        publishDir = [
+            enabled: params.save_genomes_cat
         ]
     }
 
@@ -71,14 +84,41 @@ process {
 
     withName: 'SAMPLES_SKETCH' {
         ext.args = "rna --param-string k=${params.ksize}"
+        publishDir = [
+            enabled: params.save_sourmash
+        ]
     }
 
     withName: 'GENOMES_SKETCH' {
         ext.args = "rna --param-string k=${params.ksize}"
+        publishDir = [
+            enabled: params.save_sourmash
+        ]
     }
 
     withName: 'SOURMASH_GATHER' {
         ext.args = '--threshold-bp "50"'
+        publishDir = [
+            enabled: params.save_sourmash
+        ]
+    }
+
+     withName: 'SOURMASH_INDEX' {
+        publishDir = [
+            enabled: params.save_sourmash
+        ]
+    }
+
+    withName: 'GUNZIP_GFFS' {
+        publishDir = [
+            enabled: false
+        ]
+    }
+
+    withName: 'GUNZIP' {
+        publishDir = [
+            enabled: false
+        ]
     }
 
     withName: 'GINDEX_CAT' {
@@ -119,6 +159,17 @@ process {
 
     withName: SAMTOOLS_SORT {
         ext.prefix = { "${meta.id}.sorted" }
+        publishDir = [
+            pattern: "*.bam",
+            enabled: false
+        ]
+    }
+
+    withName: SAMTOOLS_INDEX {
+        publishDir = [
+            pattern: "*.bai",
+            enabled: false
+        ]
     }
 
     withName: '.*:FEATURECOUNTS' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -103,7 +103,7 @@ process {
         ]
     }
 
-     withName: 'SOURMASH_INDEX' {
+    withName: 'SOURMASH_INDEX' {
         publishDir = [
             enabled: params.save_sourmash
         ]

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,6 +34,7 @@ params {
     // sourmash
     sourmash                    = false
     ksize                       = 21
+    save_sourmash               = false
 
     // BBmap options
     bbmap_minid                 = 0.9
@@ -49,6 +50,7 @@ params {
     multiqc_methods_description = null
 
     // Boilerplate options
+    save_genomes_cat             = false
     outdir                       = null
     publish_dir_mode             = 'copy'
     email                        = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -143,6 +143,10 @@
                 "save_bbmap_index": {
                     "type": "boolean",
                     "description": "Save ref folder containing the reference index"
+                },
+                "save_genomes_cat": {
+                    "type": "boolean",
+                    "description": "Save genomes concatenated file"
                 }
             }
         },
@@ -160,6 +164,10 @@
                     "type": "integer",
                     "default": 21,
                     "description": "K-mer size used by Sourmash"
+                },
+                "save_sourmash": {
+                    "type": "boolean",
+                    "description": "Save Sourmash outuput"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -168,6 +168,7 @@
                 "save_sourmash": {
                     "type": "boolean",
                     "description": "Save Sourmash outuput"
+                    "default": false
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -147,6 +147,7 @@
                 "save_genomes_cat": {
                     "type": "boolean",
                     "description": "Save genomes concatenated file"
+                    "default": false
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -146,7 +146,7 @@
                 },
                 "save_genomes_cat": {
                     "type": "boolean",
-                    "description": "Save genomes concatenated file"
+                    "description": "Save genomes concatenated file",
                     "default": false
                 }
             }
@@ -168,7 +168,7 @@
                 },
                 "save_sourmash": {
                     "type": "boolean",
-                    "description": "Save Sourmash outuput"
+                    "description": "Save Sourmash outuput",
                     "default": false
                 }
             }

--- a/subworkflows/local/sourmash.nf
+++ b/subworkflows/local/sourmash.nf
@@ -56,6 +56,7 @@ workflow SOURMASH {
             .set { ch_genome_sigs }
 
         GENOMES_INDEX(ch_genome_sigs, ksize)
+        ch_versions = ch_versions.mix(GENOMES_INDEX.out.versions)
 
         GENOMES_INDEX.out.signature_index
             .map{ meta, sig -> sig }


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

As explained in the title, there were many files in the output that can now be printed in ./results folder only when called with the specific option. it helps to save space.
this PR address the issue #65 

