### PR TITLE
Fix long contig names properly

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -86,6 +86,7 @@ process {
     }
 
     withName: PROKKA {
+        ext.args = '--centre X --compliant'
         storeDir = { "${params.prokka_store_dir}" }
     }
 

--- a/modules/local/format_krona/main.nf
+++ b/modules/local/format_krona/main.nf
@@ -69,7 +69,10 @@ process FORMAT_KRONA {
         c(
             "\\"${task.process}\\":",
             paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),
-            paste0("    tidyverse: ", packageVersion('tidyverse'))
+            paste0("    readr: ", packageVersion('readr')),
+            paste0("    dplyr: ", packageVersion('dplyr')),
+            paste0("    tidyr: ", packageVersion('tidyr')),
+            paste0("    stringr: ", packageVersion('stringr'))
         ),
         "versions.yml"
     )

--- a/tests/test_duplicates.nf.test.snap
+++ b/tests/test_duplicates.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_duplicates": {
         "content": [
-            58,
+            60,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18,
@@ -258,13 +258,13 @@
                 "accno\tgenome\torf"
             ],
             [
-                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tproduct"
+                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tparent\tproduct\tprotein_id"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T11:41:51.903263144"
+        "timestamp": "2025-10-06T11:38:20.013419063"
     }
 }

--- a/tests/test_sourmash.nf.test.snap
+++ b/tests/test_sourmash.nf.test.snap
@@ -220,13 +220,13 @@
                 "accno\tgenome\torf"
             ],
             [
-                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tnote\tproduct\trpt_family\trpt_type\trpt_unit_seq"
+                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tnote\tparent\tproduct\tprotein_id\trpt_family\trpt_type\trpt_unit_seq"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T11:39:11.110337332"
+        "timestamp": "2025-10-06T12:06:50.645880552"
     }
 }

--- a/tests/test_sourmash_mix.nf.test.snap
+++ b/tests/test_sourmash_mix.nf.test.snap
@@ -264,13 +264,13 @@
                 "accno\tgenome\torf"
             ],
             [
-                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tnote\tproduct\trpt_family\trpt_type\trpt_unit_seq"
+                "orf\tcontig\tgene_caller\tfeature\tstart\tend\tstrand\tdb_xref\tec_number\tgene\tinference\tlocus_tag\tname\tnote\tparent\tproduct\tprotein_id\trpt_family\trpt_type\trpt_unit_seq"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T19:26:37.970828257"
+        "timestamp": "2025-10-06T12:17:45.124049687"
     }
 }

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -281,17 +281,17 @@ workflow MAGMAP {
     GUNZIP_CONTIGS(ch_no_gff.gzipped)
     ch_versions = ch_versions.mix(GUNZIP_CONTIGS.out.versions)
 
+    // PROKKA on the genomes that lack gff
     PROKKA(GUNZIP_CONTIGS.out.file.mix(ch_no_gff.unzipped), [], [])
     ch_versions = ch_versions.mix(PROKKA.out.versions)
 
-    // PROKKA on the genomes that lack gff
+    // Mix genome entries that were not sent to Prokka with those that were
     ch_finished_genomes = ch_genomes
         .filter { g -> g.genome_gff }
         .mix(
-            PROKKA.out.gff
-                .map{ meta, gff -> [ meta.id  , [ meta.id, gff ] ] }
-                .join(ch_no_gff.gzipped.mix(ch_no_gff.unzipped).map { meta, fna -> [ meta.id , [ meta.id, fna ] ] } )
-                .map{ meta, gff, fna -> [ accno: gff[0], genome_fna: fna[1], genome_gff: gff[1] ] }
+            PROKKA.out.fna
+                .join(PROKKA.out.gff)
+                .map { meta, fna, gff -> [ accno: meta.id  , genome_fna: fna, genome_gff: gff ] }
         )
 
     //

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -286,7 +286,7 @@ workflow MAGMAP {
     ch_versions = ch_versions.mix(PROKKA.out.versions)
 
     // Mix genome entries that were not sent to Prokka with those that were
-    ch_finished_genomes = ch_genomes
+    ch_collected_genomes = ch_genomes
         .filter { g -> g.genome_gff }
         .mix(
             PROKKA.out.fna
@@ -297,13 +297,13 @@ workflow MAGMAP {
     //
     // SUBWORKFLOW: Concatenate the genome fasta files and create a BBMap index
     //
-    CREATE_BBMAP_INDEX ( ch_finished_genomes.map{ it.genome_fna } )
+    CREATE_BBMAP_INDEX(ch_collected_genomes.map{ it.genome_fna })
     ch_versions = ch_versions.mix(CREATE_BBMAP_INDEX.out.versions)
 
     //
     // SUBWORKFLOW: Concatenate gff files
     //
-    CAT_GFFS ( ch_finished_genomes.map{ it.genome_gff } )
+    CAT_GFFS(ch_collected_genomes.map{ it.genome_gff })
     ch_versions = ch_versions.mix(CAT_GFFS.out.versions)
 
     //


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

As described in the reopened #143 , contig names that are originally too long failed in the Prokka step. To fix this, I needed to change the way the contig channel is populated. Earlier, it was always the original contig file, even if Prokka was called. Now, it's taking the contig output from Prokka. Otherwise, no features will be found for files with long contig names.