### PR TITLE
Fix wrongly collected genome channel

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -14,8 +14,8 @@ params {
     genomeinfo                  = null
     indexes                     = null
     remote_genome_sources       = "https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_refseq.txt,https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_genbank.txt"
-    genome_store_dir            = 'genomes'
-    prokka_store_dir            = 'prokka'
+    genome_store_dir            = 'magmap_genomes'
+    prokka_store_dir            = 'magmap_prokka'
     gtdb_metadata               = null
     checkm_metadata             = null
     gtdbtk_metadata             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -58,7 +58,7 @@
                 "genome_store_dir": {
                     "type": "string",
                     "format": "directory-path",
-                    "default": "genomes",
+                    "default": "magmap_genomes",
                     "fa_icon": "fas fa-dna",
                     "description": "Path to a directory where downloaded genome files is stored.",
                     "help_text": "Any genome files downloaded by the pipeline will be stored in this directory for potential later use."
@@ -66,7 +66,7 @@
                 "prokka_store_dir": {
                     "type": "string",
                     "format": "directory-path",
-                    "default": "prokka",
+                    "default": "magmap_prokka",
                     "fa_icon": "fas fa-dna",
                     "description": "Path to a directory where prokka output is stored.",
                     "help_text": "Prokka annotation files created by the pipeline will be stored in this directory for potential later use."

--- a/subworkflows/local/sourmash/main.nf
+++ b/subworkflows/local/sourmash/main.nf
@@ -42,7 +42,8 @@ workflow SOURMASH {
         ch_sample_sigs = SAMPLE_SKETCH.out.signatures
 
         ch_genome_sigs = GENOME_SKETCH.out.signatures
-            .collect { meta, sig -> [ [ id: 'local-genomes' ], sig ] }
+            .collect { meta, sig -> sig }
+            .map { sigs -> [ [ id: 'local-genomes' ], sigs ] }
 
         GENOME_INDEX(ch_genome_sigs, ksize)
         ch_versions = ch_versions.mix(GENOME_INDEX.out.versions)


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

The channel that collects genomes to pass from sketching to indexing was wrongly collected. Is hopefully fixed with this, but there's no test for this bug.

I also changed the defaults for `genome_store_dir` and `prokka_store_dir`.