### PR TITLE
avoid empty ch_versions in trimagalore subworkflow

### DIFF
--- a/conf/test_skip_preprocessing.config
+++ b/conf/test_skip_preprocessing.config
@@ -1,0 +1,33 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/magmap -profile test,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
+params {
+    config_profile_name        = 'Test skipping preprocessing steps profile'
+    config_profile_description = 'Minimal test dataset to check pipeline function when skipping preprocessing steps'
+
+    // Input data
+    input           = params.pipelines_testdata_base_path + 'magmap/samplesheets/samplesheet.csv'
+    genomeinfo      = params.pipelines_testdata_base_path + 'magmap/testdata/genometest.csv'
+    sequence_filter = params.pipelines_testdata_base_path + 'metatdenovo/test_data/rrna.fna.gz'
+    skip_qc         = true
+    skip_fasqc      = true
+    skip_trimming   = true
+
+}

--- a/conf/test_skip_preprocessing.config
+++ b/conf/test_skip_preprocessing.config
@@ -27,7 +27,7 @@ params {
     genomeinfo      = params.pipelines_testdata_base_path + 'magmap/testdata/genometest.csv'
     sequence_filter = params.pipelines_testdata_base_path + 'metatdenovo/test_data/rrna.fna.gz'
     skip_qc         = true
-    skip_fasqc      = true
+    skip_fastqc      = true
     skip_trimming   = true
 
 }

--- a/modules.json
+++ b/modules.json
@@ -8,155 +8,113 @@
                     "bbmap/align": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
                     },
                     "bbmap/bbduk": {
                         "branch": "master",
                         "git_sha": "3351c212144fc8aab0e595165bf447ebecfebd8a",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
                     },
                     "bbmap/index": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/bbmap/index/bbmap-index.diff"
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "e10b76ca0c66213581bec2833e30d31f239dec0b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pigz/compress": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "prokka": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/prokka/prokka.diff"
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "e334e12a1e985adc5ffc3fc78a68be1de711de45",
-                        "installed_by": [
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["bam_stats_samtools"]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": [
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["bam_stats_samtools"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": [
-                            "bam_sort_stats_samtools"
-                        ]
+                        "installed_by": ["bam_sort_stats_samtools"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": [
-                            "bam_sort_stats_samtools"
-                        ]
+                        "installed_by": ["bam_sort_stats_samtools"]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": [
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["bam_stats_samtools"]
                     },
                     "sourmash/gather": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/sourmash/gather/sourmash-gather.diff"
                     },
                     "sourmash/index": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "sourmash/sketch": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/subread/featurecounts/subread-featurecounts.diff"
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "wget": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/wget/wget.diff"
                     }
                 }
@@ -166,37 +124,27 @@
                     "bam_sort_stats_samtools": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "bam_stats_samtools": {
                         "branch": "master",
                         "git_sha": "e334e12a1e985adc5ffc3fc78a68be1de711de45",
-                        "installed_by": [
-                            "bam_sort_stats_samtools"
-                        ]
+                        "installed_by": ["bam_sort_stats_samtools"]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,112 +8,155 @@
                     "bbmap/align": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
                     },
                     "bbmap/bbduk": {
                         "branch": "master",
                         "git_sha": "3351c212144fc8aab0e595165bf447ebecfebd8a",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
                     },
                     "bbmap/index": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/bbmap/index/bbmap-index.diff"
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "e10b76ca0c66213581bec2833e30d31f239dec0b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pigz/compress": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "prokka": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/prokka/prokka.diff"
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "e334e12a1e985adc5ffc3fc78a68be1de711de45",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": ["bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": ["bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "sourmash/gather": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/sourmash/gather/sourmash-gather.diff"
                     },
                     "sourmash/index": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "sourmash/sketch": {
                         "branch": "master",
                         "git_sha": "30c7adaae047db8e06f71386eb6059fdd1ea6b13",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/subread/featurecounts/subread-featurecounts.diff"
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "wget": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/wget/wget.diff"
                     }
                 }
@@ -123,27 +166,37 @@
                     "bam_sort_stats_samtools": {
                         "branch": "master",
                         "git_sha": "c8be52dba1166c678e74cda9c3a3c221635c8bb1",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_stats_samtools": {
                         "branch": "master",
                         "git_sha": "e334e12a1e985adc5ffc3fc78a68be1de711de45",
-                        "installed_by": ["bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "4b406a74dc0449c0401ed87d5bfff4252fd277fd",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff
+++ b/modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff
@@ -1,0 +1,20 @@
+Changes in component 'nf-core/bbmap/bbduk'
+'modules/nf-core/bbmap/bbduk/environment.yml' is unchanged
+'modules/nf-core/bbmap/bbduk/meta.yml' is unchanged
+Changes in 'bbmap/bbduk/main.nf':
+--- modules/nf-core/bbmap/bbduk/main.nf
++++ modules/nf-core/bbmap/bbduk/main.nf
+@@ -23,7 +23,7 @@
+     def args = task.ext.args ?: ''
+     def prefix = task.ext.prefix ?: "${meta.id}"
+     def raw      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+-    def trimmed  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
++    def trimmed  = meta.single_end ? "out=${prefix}.clean.fastq.gz" : "out1=${prefix}.clean_1.fastq.gz out2=${prefix}.clean_2.fastq.gz"
+     def contaminants_fa = contaminants ? "ref=$contaminants" : ''
+     """
+     bbduk.sh \\
+
+'modules/nf-core/bbmap/bbduk/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/bbmap/bbduk/tests/nextflow.config' is unchanged
+'modules/nf-core/bbmap/bbduk/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/nf-core/bbmap/bbduk/main.nf
+++ b/modules/nf-core/bbmap/bbduk/main.nf
@@ -23,7 +23,7 @@ process BBMAP_BBDUK {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def raw      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
-    def trimmed  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
+    def trimmed  = meta.single_end ? "out=${prefix}.clean.fastq.gz" : "out1=${prefix}.clean_1.fastq.gz out2=${prefix}.clean_2.fastq.gz"
     def contaminants_fa = contaminants ? "ref=$contaminants" : ''
     """
     bbduk.sh \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -202,13 +202,14 @@ profiles {
         apptainer.runOptions    = '--nv'
         singularity.runOptions  = '--nv'
     }
-    test                { includeConfig 'conf/test.config'              }
-    test_duplicates     { includeConfig 'conf/test_duplicates.config'   }
-    test_full           { includeConfig 'conf/test_full.config'         }
-    test_metadata       { includeConfig 'conf/test_metadata.config'     }
-    test_single         { includeConfig 'conf/test_single.config'       }
-    test_sourmash       { includeConfig 'conf/test_sourmash.config'     }
-    test_sourmash_mix   { includeConfig 'conf/test_sourmash_mix.config' }
+    test                          { includeConfig 'conf/test.config'                    }
+    test_skip_preprocessing_steps { includeConfig 'conf/test_skip_preprocessing.config' }
+    test_duplicates               { includeConfig 'conf/test_duplicates.config'         }
+    test_full                     { includeConfig 'conf/test_full.config'               }
+    test_metadata                 { includeConfig 'conf/test_metadata.config'           }
+    test_single                   { includeConfig 'conf/test_single.config'             }
+    test_sourmash                 { includeConfig 'conf/test_sourmash.config'           }
+    test_sourmash_mix             { includeConfig 'conf/test_sourmash_mix.config'       }
 }
 
 // If params.custom_config_base is set AND either the NXF_OFFLINE environment variable is not set or params.custom_config_base is a local path, the nfcore_custom.config file from the specified base path is included.

--- a/subworkflows/local/fastqc_trimgalore/main.nf
+++ b/subworkflows/local/fastqc_trimgalore/main.nf
@@ -45,5 +45,6 @@ workflow FASTQC_TRIMGALORE {
     trim_zip           // channel: [ val(meta), [ zip ] ]
     trim_log           // channel: [ val(meta), [ txt ] ]
 
-    versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+    versions = ch_versions // channel: [ versions.yml ]
+
 }

--- a/tests/test_skip_preprocessing_steps.nf.test
+++ b/tests/test_skip_preprocessing_steps.nf.test
@@ -3,7 +3,7 @@ nextflow_pipeline {
     name "Test pipeline"
     script "../main.nf"
     tag "pipeline"
-    profile 'test skip preprocessing steps'
+    profile 'test_skip_preprocessing_steps'
 
     test("-profile test_skip_preprocessing_steps") {
 

--- a/tests/test_skip_preprocessing_steps.nf.test
+++ b/tests/test_skip_preprocessing_steps.nf.test
@@ -1,0 +1,60 @@
+nextflow_pipeline {
+
+    name "Test pipeline"
+    script "../main.nf"
+    tag "pipeline"
+    profile 'test skip preprocessing steps'
+
+    test("-profile test_skip_preprocessing_steps") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_magmap_software_mqc_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path,
+                    // Important files with unstable content
+                    path("${params.outdir}/summary_tables/magmap.overall_stats.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') },
+                    path("${params.outdir}/summary_tables/magmap.overall_stats.tsv.gz").linesGzip.size(),
+                    path("${params.outdir}/summary_tables/magmap.overall_stats.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["n_post_trimming"].sum(),
+                    path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["tpm"].sum().round(),
+                    path("${params.outdir}/summary_tables/magmap.rRNA.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    path("${params.outdir}/summary_tables/magmap.rRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["tpm"].sum().round(),
+                    path("${params.outdir}/summary_tables/magmap.tmRNA.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    path("${params.outdir}/summary_tables/magmap.tmRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["tpm"].sum().toBigDecimal().round(),
+                    path("${params.outdir}/summary_tables/magmap.tRNA.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    path("${params.outdir}/summary_tables/magmap.tRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["tpm"].sum().round(),
+                    path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('accno') },
+                    path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('GCA') },
+                    path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.findAll { l -> l.contains('accno') },
+                    path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                ).match() },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 500 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["count"].sum() > 500 },
+                { assert path("${params.outdir}/summary_tables/magmap.rRNA.counts.tsv.gz").linesGzip.size() > 5 },
+                { assert path("${params.outdir}/summary_tables/magmap.rRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["count"].sum() > 10 },
+                { assert path("${params.outdir}/summary_tables/magmap.tmRNA.counts.tsv.gz").linesGzip.size() > 1 },
+                { assert path("${params.outdir}/summary_tables/magmap.tmRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["count"].sum() > 1 },
+                { assert path("${params.outdir}/summary_tables/magmap.tRNA.counts.tsv.gz").linesGzip.size() > 20 },
+                { assert path("${params.outdir}/summary_tables/magmap.tRNA.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["count"].sum() > 15 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 400 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 400 },
+            )
+        }
+    }
+}

--- a/tests/test_skip_preprocessing_steps.nf.test.snap
+++ b/tests/test_skip_preprocessing_steps.nf.test.snap
@@ -1,0 +1,280 @@
+{
+    "-profile test_skip_preprocessing_steps": {
+        "content": [
+            {
+                "BBMAP_ALIGN": {
+                    "bbmap": 39.18,
+                    "samtools": 1.21,
+                    "pigz": 2.8
+                },
+                "BBMAP_BBDUK": {
+                    "bbmap": 39.18
+                },
+                "BBMAP_INDEX": {
+                    "bbmap": 39.18
+                },
+                "CATPROKKATSVS": {
+                    "pigz": 2.8
+                },
+                "CAT_FNA": {
+                    "pigz": 2.6
+                },
+                "CAT_GFF": {
+                    "pigz": 2.6
+                },
+                "CHECK_DUPLICATES": {
+                    "zgrep": 1.5
+                },
+                "COLLECT_FEATURECOUNTS": {
+                    "R": "4.3.1",
+                    "dplyr": "1.1.4",
+                    "dtplyr": "1.3.2",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_STATS": {
+                    "R": "4.3.1",
+                    "dplyr": "1.1.4",
+                    "readr": "2.1.5",
+                    "purrr": "1.1.0",
+                    "tidyr": "1.3.1",
+                    "stringr": "1.5.2"
+                },
+                "FASTQC": {
+                    "fastqc": "0.12.1"
+                },
+                "FEATURECOUNTS": {
+                    "subread": "2.0.6"
+                },
+                "GENOMES2ORFS": {
+                    "sed": 4.9
+                },
+                "PROKKAGFF2TSV": {
+                    "R": "4.3.1",
+                    "data.table": "1.17.8",
+                    "dtplyr": "1.3.2",
+                    "dplyr": "1.1.4",
+                    "tidyr": "1.3.1",
+                    "readr": "2.1.5"
+                },
+                "SAMTOOLS_FLAGSTAT": {
+                    "samtools": "1.22.1"
+                },
+                "SAMTOOLS_IDXSTATS": {
+                    "samtools": "1.22.1"
+                },
+                "SAMTOOLS_INDEX": {
+                    "samtools": "1.22.1"
+                },
+                "SAMTOOLS_SORT": {
+                    "samtools": "1.22.1"
+                },
+                "SAMTOOLS_STATS": {
+                    "samtools": "1.22.1"
+                },
+                "TIDYVERSE_JOINMETADATA": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4",
+                    "tidyr": "1.3.1",
+                    "stringr": "1.5.2"
+                },
+                "Workflow": {
+                    "nf-core/magmap": "v1.0.0"
+                }
+            },
+            [
+                "bbmap",
+                "bbmap/logs",
+                "bbmap/logs/s0.bbmap.log",
+                "bbmap/logs/s1.bbmap.log",
+                "bbmap/logs/s2.bbmap.log",
+                "fastqc",
+                "fastqc/s0_1_fastqc.html",
+                "fastqc/s0_2_fastqc.html",
+                "fastqc/s1_1_fastqc.html",
+                "fastqc/s1_2_fastqc.html",
+                "fastqc/s2_1_fastqc.html",
+                "fastqc/s2_2_fastqc.html",
+                "featurecounts",
+                "featurecounts/s0.CDS.featureCounts.tsv",
+                "featurecounts/s0.CDS.featureCounts.tsv.summary",
+                "featurecounts/s0.rRNA.featureCounts.tsv",
+                "featurecounts/s0.rRNA.featureCounts.tsv.summary",
+                "featurecounts/s0.tRNA.featureCounts.tsv",
+                "featurecounts/s0.tRNA.featureCounts.tsv.summary",
+                "featurecounts/s0.tmRNA.featureCounts.tsv",
+                "featurecounts/s0.tmRNA.featureCounts.tsv.summary",
+                "featurecounts/s1.CDS.featureCounts.tsv",
+                "featurecounts/s1.CDS.featureCounts.tsv.summary",
+                "featurecounts/s1.rRNA.featureCounts.tsv",
+                "featurecounts/s1.rRNA.featureCounts.tsv.summary",
+                "featurecounts/s1.tRNA.featureCounts.tsv",
+                "featurecounts/s1.tRNA.featureCounts.tsv.summary",
+                "featurecounts/s1.tmRNA.featureCounts.tsv",
+                "featurecounts/s1.tmRNA.featureCounts.tsv.summary",
+                "featurecounts/s2.CDS.featureCounts.tsv",
+                "featurecounts/s2.CDS.featureCounts.tsv.summary",
+                "featurecounts/s2.rRNA.featureCounts.tsv",
+                "featurecounts/s2.rRNA.featureCounts.tsv.summary",
+                "featurecounts/s2.tRNA.featureCounts.tsv",
+                "featurecounts/s2.tRNA.featureCounts.tsv.summary",
+                "featurecounts/s2.tmRNA.featureCounts.tsv",
+                "featurecounts/s2.tmRNA.featureCounts.tsv.summary",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/bbduk-filtered-barplot_Bases.txt",
+                "multiqc/multiqc_data/bbduk-filtered-barplot_Reads.txt",
+                "multiqc/multiqc_data/bbduk.txt",
+                "multiqc/multiqc_data/fastqc-status-check-heatmap.txt",
+                "multiqc/multiqc_data/fastqc_adapter_content_plot.txt",
+                "multiqc/multiqc_data/fastqc_overrepresented_sequences_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_base_n_content_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_base_sequence_quality_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_gc_content_plot_Counts.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_gc_content_plot_Percentages.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_quality_scores_plot.txt",
+                "multiqc/multiqc_data/fastqc_sequence_counts_plot.txt",
+                "multiqc/multiqc_data/fastqc_sequence_duplication_levels_plot.txt",
+                "multiqc/multiqc_data/fastqc_top_overrepresented_sequences_table.txt",
+                "multiqc/multiqc_data/featureCounts_assignment_plot.txt",
+                "multiqc/multiqc_data/llms-full.txt",
+                "multiqc/multiqc_data/multiqc.log",
+                "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_citations.txt",
+                "multiqc/multiqc_data/multiqc_data.json",
+                "multiqc/multiqc_data/multiqc_fastqc.txt",
+                "multiqc/multiqc_data/multiqc_featurecounts.txt",
+                "multiqc/multiqc_data/multiqc_general_stats.txt",
+                "multiqc/multiqc_data/multiqc_software_versions.txt",
+                "multiqc/multiqc_data/multiqc_sources.txt",
+                "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/pdf",
+                "multiqc/multiqc_plots/pdf/bbduk-filtered-barplot_Bases-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/bbduk-filtered-barplot_Bases-pct.pdf",
+                "multiqc/multiqc_plots/pdf/bbduk-filtered-barplot_Reads-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/bbduk-filtered-barplot_Reads-pct.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc-status-check-heatmap.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_adapter_content_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_overrepresented_sequences_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_per_base_n_content_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_per_base_sequence_quality_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_per_sequence_gc_content_plot_Counts.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_per_sequence_gc_content_plot_Percentages.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_per_sequence_quality_scores_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_sequence_counts_plot-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_sequence_counts_plot-pct.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_sequence_duplication_levels_plot.pdf",
+                "multiqc/multiqc_plots/pdf/fastqc_top_overrepresented_sequences_table.pdf",
+                "multiqc/multiqc_plots/pdf/featureCounts_assignment_plot-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/featureCounts_assignment_plot-pct.pdf",
+                "multiqc/multiqc_plots/png",
+                "multiqc/multiqc_plots/png/bbduk-filtered-barplot_Bases-cnt.png",
+                "multiqc/multiqc_plots/png/bbduk-filtered-barplot_Bases-pct.png",
+                "multiqc/multiqc_plots/png/bbduk-filtered-barplot_Reads-cnt.png",
+                "multiqc/multiqc_plots/png/bbduk-filtered-barplot_Reads-pct.png",
+                "multiqc/multiqc_plots/png/fastqc-status-check-heatmap.png",
+                "multiqc/multiqc_plots/png/fastqc_adapter_content_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_overrepresented_sequences_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_per_base_n_content_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_per_base_sequence_quality_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_per_sequence_gc_content_plot_Counts.png",
+                "multiqc/multiqc_plots/png/fastqc_per_sequence_gc_content_plot_Percentages.png",
+                "multiqc/multiqc_plots/png/fastqc_per_sequence_quality_scores_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_sequence_counts_plot-cnt.png",
+                "multiqc/multiqc_plots/png/fastqc_sequence_counts_plot-pct.png",
+                "multiqc/multiqc_plots/png/fastqc_sequence_duplication_levels_plot.png",
+                "multiqc/multiqc_plots/png/fastqc_top_overrepresented_sequences_table.png",
+                "multiqc/multiqc_plots/png/featureCounts_assignment_plot-cnt.png",
+                "multiqc/multiqc_plots/png/featureCounts_assignment_plot-pct.png",
+                "multiqc/multiqc_plots/svg",
+                "multiqc/multiqc_plots/svg/bbduk-filtered-barplot_Bases-cnt.svg",
+                "multiqc/multiqc_plots/svg/bbduk-filtered-barplot_Bases-pct.svg",
+                "multiqc/multiqc_plots/svg/bbduk-filtered-barplot_Reads-cnt.svg",
+                "multiqc/multiqc_plots/svg/bbduk-filtered-barplot_Reads-pct.svg",
+                "multiqc/multiqc_plots/svg/fastqc-status-check-heatmap.svg",
+                "multiqc/multiqc_plots/svg/fastqc_adapter_content_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_overrepresented_sequences_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_per_base_n_content_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_per_base_sequence_quality_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_per_sequence_gc_content_plot_Counts.svg",
+                "multiqc/multiqc_plots/svg/fastqc_per_sequence_gc_content_plot_Percentages.svg",
+                "multiqc/multiqc_plots/svg/fastqc_per_sequence_quality_scores_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_sequence_counts_plot-cnt.svg",
+                "multiqc/multiqc_plots/svg/fastqc_sequence_counts_plot-pct.svg",
+                "multiqc/multiqc_plots/svg/fastqc_sequence_duplication_levels_plot.svg",
+                "multiqc/multiqc_plots/svg/fastqc_top_overrepresented_sequences_table.svg",
+                "multiqc/multiqc_plots/svg/featureCounts_assignment_plot-cnt.svg",
+                "multiqc/multiqc_plots/svg/featureCounts_assignment_plot-pct.svg",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nf_core_magmap_software_mqc_versions.yml",
+                "summary_tables",
+                "summary_tables/magmap.CDS.counts.tsv.gz",
+                "summary_tables/magmap.genome_metadata.tsv.gz",
+                "summary_tables/magmap.genomes2orfs.tsv.gz",
+                "summary_tables/magmap.overall_stats.tsv.gz",
+                "summary_tables/magmap.prokka-annotations.tsv.gz",
+                "summary_tables/magmap.rRNA.counts.tsv.gz",
+                "summary_tables/magmap.tRNA.counts.tsv.gz",
+                "summary_tables/magmap.tmRNA.counts.tsv.gz"
+            ],
+            [
+                "bbduk-filtered-barplot_Bases.txt:md5,1030946639af805c0ac9b3efa3958322",
+                "bbduk-filtered-barplot_Reads.txt:md5,f5427b2a7c2659cf4c01d82dc0cd0eb8",
+                "bbduk.txt:md5,d827b9375317040014b400d56010c0a2",
+                "fastqc-status-check-heatmap.txt:md5,dc1bf56fcdaf9d486c808354b9af6fc6",
+                "fastqc_adapter_content_plot.txt:md5,847ded8ccf3c10ab66d421e61933a899",
+                "fastqc_overrepresented_sequences_plot.txt:md5,882815485253c9c8d4dcbf3c3d58d364",
+                "fastqc_per_base_n_content_plot.txt:md5,63f48e7650148b7c49b9e4ea0ab57abb",
+                "fastqc_per_base_sequence_quality_plot.txt:md5,9b42854a4b81fc0f76684960682ba25e",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,94d18520ec9f2cf01b9f8c41078eb77f",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,d8f4cd87ddbcfcfbcaf87bf42b64b012",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,3d32fc7eed7468abed6450cc8c7c3322",
+                "fastqc_sequence_counts_plot.txt:md5,aa8603ccb9c0d0d188281d1764f03330",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,f8316c4463604b6c67902115f894f429",
+                "featureCounts_assignment_plot.txt:md5,6ece6d71043ef3d3489c0ece9bb5b0f1",
+                "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
+                "multiqc_fastqc.txt:md5,ce7f1eb1bdf9591922528372e806963d",
+                "multiqc_featurecounts.txt:md5,754487a0f6142b20e84a73e7cf576178"
+            ],
+            [
+                "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA\ttmRNA"
+            ],
+            4,
+            "",
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            3000000,
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            3000000,
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            1000000,
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            3000000,
+            [
+                "accno\tcheckm_completeness\tcheckm_contamination\tcheckm_strain_heterogeneity\tcontig_count\tgenome_size\tgtdb_genome_representative\tgtdb_representative\tgtdb_taxonomy\tsource\tpriority"
+            ],
+            [
+                "GCA_002688505.1\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA\tNA"
+            ],
+            [
+                "accno\tgenome\torf"
+            ],
+            [
+                "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-11-12T14:15:20.607608"
+    }
+}

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -149,7 +149,6 @@ workflow MAGMAP {
 
     ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
 
-    ch_versions.view()
     ch_collect_stats = ch_short_reads
         .collect { meta, fasta -> meta }
         .map { reads -> [ [ id: 'magmap' ], reads ] }

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -146,7 +146,10 @@ workflow MAGMAP {
         skip_fastqc || skip_qc,
         skip_trimming
     )
+
+    if ((skip_fastqc && skip_qc) || skip_trimming) {
     ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
+    }
 
     ch_collect_stats = ch_short_reads
         .collect { meta, fasta -> meta }

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -147,10 +147,9 @@ workflow MAGMAP {
         skip_trimming
     )
 
-    if ((skip_fastqc && skip_qc) || skip_trimming) {
-        ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
-    }
+    ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
 
+    ch_versions.view()
     ch_collect_stats = ch_short_reads
         .collect { meta, fasta -> meta }
         .map { reads -> [ [ id: 'magmap' ], reads ] }

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -148,7 +148,7 @@ workflow MAGMAP {
     )
 
     if ((skip_fastqc && skip_qc) || skip_trimming) {
-    ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
+        ch_versions = ch_versions.mix(FASTQC_TRIMGALORE.out.versions)
     }
 
     ch_collect_stats = ch_short_reads


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

with the combination of parameters

´skip_qc´, ´skip_fastqc´and/or ´skip_trimming` the pipeline failed because the ch_versions gets empty.