### PR TITLE
Document read-count units and fix brittle R code in COLLECT_STATS/COLLECT_GENOMESELECTION

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -27,9 +27,7 @@ env:
 jobs:
   nf-test-changes:
     name: nf-test-changes
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-nf-test-changes
-      - runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -61,9 +59,7 @@ jobs:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
     if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-nf-test
-      - runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -138,9 +134,7 @@ jobs:
   confirm-pass:
     needs: [nf-test]
     if: always()
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-confirm-pass
-      - runner=2cpu-linux-x64
+    runs-on: ubuntu-latest
     steps:
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#NN](https://github.com/nf-core/magmap/pull/NN) - Define TPM calculation in docs/output.md (by @erikrikarddaniel).
+- [#222](https://github.com/nf-core/magmap/pull/222) - Define TPM calculation in docs/output.md (by @erikrikarddaniel).
 - [#215](https://github.com/nf-core/magmap/pull/215) - Template update for nf-core/tools version 4.0.3, and update nf-core modules and subworkflows (by @erikrikarddaniel).
 
 ### `Fixed`
 
-- [#NN](https://github.com/nf-core/magmap/pull/NN) - Fix brittle R code in `COLLECT_STATS`/`COLLECT_GENOMESELECTION`: safely escape user-controlled values (sample IDs, genome accessions) embedded in generated R source, avoid shelling out to parse trimming/BBDuk/idxstats files, and type featureCounts columns by name instead of position ([#218](https://github.com/nf-core/magmap/issues/218), by @erikrikarddaniel).
+- [#222](https://github.com/nf-core/magmap/pull/222) - Fix brittle R code in `COLLECT_STATS`/`COLLECT_GENOMESELECTION` ([#218](https://github.com/nf-core/magmap/issues/218), by @erikrikarddaniel).
 - [#217](https://github.com/nf-core/magmap/pull/217) - Report the Prokka version in the collated `versions.yml`/MultiQC report; it was silently never being collected (by @erikrikarddaniel).
 - [#215](https://github.com/nf-core/magmap/pull/215) - Fix a CI issue affecting Singularity/Apptainer test jobs (by @erikrikarddaniel).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Define TPM calculation in docs/output.md (by @erikrikarddaniel).
 - [#215](https://github.com/nf-core/magmap/pull/215) - Template update for nf-core/tools version 4.0.3, and update nf-core modules and subworkflows (by @erikrikarddaniel).
 
 ### `Fixed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Fix brittle R code in `COLLECT_STATS`/`COLLECT_GENOMESELECTION`: safely escape user-controlled values (sample IDs, genome accessions) embedded in generated R source, avoid shelling out to parse trimming/BBDuk/idxstats files, and type featureCounts columns by name instead of position ([#218](https://github.com/nf-core/magmap/issues/218), by @erikrikarddaniel).
 - [#217](https://github.com/nf-core/magmap/pull/217) - Report the Prokka version in the collated `versions.yml`/MultiQC report; it was silently never being collected (by @erikrikarddaniel).
 - [#215](https://github.com/nf-core/magmap/pull/215) - Fix a CI issue affecting Singularity/Apptainer test jobs (by @erikrikarddaniel).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#222](https://github.com/nf-core/magmap/pull/222) - Fix brittle R code in `COLLECT_STATS`/`COLLECT_GENOMESELECTION` ([#218](https://github.com/nf-core/magmap/issues/218), by @erikrikarddaniel).
+- [#222](https://github.com/nf-core/magmap/pull/222) - Fix an intermittent `ConcurrentModificationException` in `COLLECT_GENOMESELECTION` caused by two channel subscribers sharing a mutable genome-accession list (by @erikrikarddaniel).
 - [#217](https://github.com/nf-core/magmap/pull/217) - Report the Prokka version in the collated `versions.yml`/MultiQC report; it was silently never being collected (by @erikrikarddaniel).
 - [#215](https://github.com/nf-core/magmap/pull/215) - Fix a CI issue affecting Singularity/Apptainer test jobs (by @erikrikarddaniel).
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -38,7 +38,7 @@ With [`--save_parquet`](https://nf-co.re/magmap/parameters/#save_parquet), the s
 
 - `summary_tables/`
   - `magmap.overall_stats.tsv.gz`: Overall statistics from the pipeline, e.g. number of reads, number of called ORFs, number of reads mapping back to contigs/ORFs etc.
-  - `magmap.<FEATURE>.counts.tsv.gz`: Read counts for `FEATURE` per ORF and sample.
+  - `magmap.<FEATURE>.counts.tsv.gz`: Read counts and TPMs for `FEATURE` per ORF and sample. TPMs are calculated as: `r = count/length; tpm = r/sum(r)` over each sample, i.e. a length-corrected relative abundance.
   - `magmap.genome_metadata.tsv.gz`: Genome metadata from GTDB, GTDB-Tk and CheckM/CheckM2 if provided by the user.
   - `magmap.genome_selection.tsv.gz`: Per genome set (one per sample when `--genomeset_mode sample` is used, a single set otherwise), which genomes were selected and whether each originated from `--genomeinfo` (local) or was fetched from NCBI (remote).
   - `magmap.genomes2orfs.tsv.gz`: Translation table from ORF identifiers to genome identifiers.

--- a/modules/local/collect/genomeselection/main.nf
+++ b/modules/local/collect/genomeselection/main.nf
@@ -1,3 +1,11 @@
+// Safely quote a Groovy value as a single-quoted R string literal. Used everywhere
+// below that a sample ID or genome accession (documented as accepting arbitrary text
+// via --genomeinfo) gets embedded into generated R source -- without this, a value
+// containing a quote could break the generated R syntax, or worse.
+def rq(v) {
+    return "'" + v.toString().replace('\\', '\\\\').replace("'", "\\'") + "'"
+}
+
 process COLLECT_GENOMESELECTION {
     tag "$meta.id"
     label 'process_single'
@@ -22,10 +30,10 @@ process COLLECT_GENOMESELECTION {
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
     def local_accnos_r = local_accnos ?
-        "c(${local_accnos.collect { a -> "'${a}'" }.join(', ')})" :
+        "c(${local_accnos.collect { a -> rq(a) }.join(', ')})" :
         "character(0)"
     def genome_set_rows = genome_sets.collectMany { s ->
-        s.accnos.collect { accno -> "'${s.id}', '${accno}'," }
+        s.accnos.collect { accno -> "${rq(s.id)}, ${rq(accno)}," }
     }
     """
     #!/usr/bin/env Rscript

--- a/modules/local/collect/stats/main.nf
+++ b/modules/local/collect/stats/main.nf
@@ -109,8 +109,8 @@ process COLLECT_STATS {
 
     ${read_trimlogs}
 
-    # Reading each idxstats file directly (instead of shelling out to `grep -v '^\*'`)
-    # avoids passing a sample-derived filename through a shell command string.
+    # Reading each idxstats file directly instead of shelling out to grep, to avoid
+    # passing a sample-derived filename through a shell command string.
     idxs <- tibble(fname = Sys.glob('*.idxstats')) %>%
         mutate(
             sample = str_remove(basename(fname), '.idxstats'),

--- a/modules/local/collect/stats/main.nf
+++ b/modules/local/collect/stats/main.nf
@@ -1,3 +1,12 @@
+// Safely quote a Groovy value as a single-quoted R string literal. Used everywhere
+// below that a sample ID or other user-controlled value (e.g. from --genomeinfo,
+// documented as accepting arbitrary text) gets embedded into generated R source --
+// without this, a value containing a quote could break the generated R syntax, or
+// worse.
+def rq(v) {
+    return "'" + v.toString().replace('\\', '\\\\').replace("'", "\\'") + "'"
+}
+
 process COLLECT_STATS {
     tag "$meta.id"
     label 'process_medium'
@@ -25,10 +34,10 @@ process COLLECT_STATS {
     if ( trimlogs ) {
         def se_trimlogs = samples
             .findAll { s -> s.single_end }
-            .collect { s -> "'${s.id}', '${s.id}.*_trimming_report.txt', 1," }
+            .collect { s -> "${rq(s.id)}, ${rq(s.id + '.*_trimming_report.txt')}, 1," }
         def pe_trimlogs = samples
             .findAll { s -> ! s.single_end }
-            .collect { s -> "'${s.id}', '${s.id}_1.*_trimming_report.txt', 2," }
+            .collect { s -> "${rq(s.id)}, ${rq(s.id + '_1.*_trimming_report.txt')}, 2," }
 
         read_trimlogs = """
         trimming <- tribble(
@@ -39,12 +48,15 @@ process COLLECT_STATS {
             mutate(
                 d = map(
                     tlogglob,
-                    function(s) {
-                        read_tsv(
-                            pipe(sprintf("grep 'Reads written (passing filters)' %s | sed 's/.*: *//' | sed 's/ .*//' | sed 's/,//g'", s)),
-                            col_names = c('n_post_trimming'),
-                            col_types = 'i'
-                        )
+                    function(g) {
+                        # Deliberately using Sys.glob() + readLines() rather than shelling
+                        # out to grep/sed via pipe(sprintf(...)): the glob and file content
+                        # are only ever passed as R function arguments here, never
+                        # interpolated into a shell command string.
+                        f <- Sys.glob(g)[1]
+                        line <- grep('Reads written \\\\(passing filters\\\\)', readLines(f), value = TRUE)
+                        n <- as.integer(gsub(',', '', sub(' .*', '', sub('.*: *', '', line))))
+                        tibble(n_post_trimming = n)
                     }
                 )
             ) %>%
@@ -93,18 +105,20 @@ process COLLECT_STATS {
     library(tidyr)
     library(stringr)
 
-    start    <- tibble(sample = c("${samples.collect { s -> s.id }.join('", "')}"))
+    start    <- tibble(sample = c(${samples.collect { s -> rq(s.id) }.join(', ')}))
 
     ${read_trimlogs}
 
+    # Reading each idxstats file directly (instead of shelling out to `grep -v '^\*'`)
+    # avoids passing a sample-derived filename through a shell command string.
     idxs <- tibble(fname = Sys.glob('*.idxstats')) %>%
         mutate(
             sample = str_remove(basename(fname), '.idxstats'),
             d = map(
                 fname,
                 \\(f) {
-                    read_tsv(pipe(sprintf("grep -v '^\\\\*' %s", f)), col_names = c('chr', 'length', 'idxs_n_mapped', 'idxs_n_unmapped'), col_types = 'ciii') %>%
-                        select(-chr, -length) %>%
+                    read_tsv(f, col_names = c('chr', 'length', 'idxs_n_mapped', 'idxs_n_unmapped'), col_types = 'ciii') %>%
+                        filter(chr != '*') %>%
                         summarise(idxs_n_mapped = sum(idxs_n_mapped), idxs_n_unmapped = sum(idxs_n_unmapped))
                 }
             )
@@ -112,24 +126,39 @@ process COLLECT_STATS {
         unnest(d) %>%
         select(-fname)
 
-    counts <- read_tsv(c('${fcs.join("', '")}'), col_types = 'ccciicicid', id = 'fname') %>%
+    # Column types given by name rather than position (contrast the old
+    # col_types = 'ccciicicid'): this only depends on COLLECT_FEATURECOUNTS's output
+    # columns existing and being correctly typed, not also on their order, so a future
+    # column reorder there won't silently misparse here.
+    counts <- read_tsv(
+        c('${fcs.join("', '")}'),
+        id = 'fname',
+        col_types = cols(
+            accno  = col_character(),
+            orf    = col_character(),
+            chr    = col_character(),
+            start  = col_integer(),
+            end    = col_integer(),
+            strand = col_character(),
+            length = col_integer(),
+            sample = col_character(),
+            count  = col_integer(),
+            tpm    = col_double()
+        )
+    ) %>%
         mutate(feature = str_replace(fname, '^[^.]+\\\\.([^.]+)\\\\..*', '\\\\1')) %>%
         group_by(sample, feature) %>%
         summarise(count = sum(count), .groups = 'drop') %>%
         pivot_wider(names_from = feature, values_from = count, values_fill = 0)
 
+    # Reading each bbduk log directly (instead of shelling out to grep/sed) avoids
+    # passing a sample-derived filename through a shell command string.
     bbduk <- tibble(sample = character(), n_non_contaminated = integer())
     for ( f in Sys.glob('*.bbduk.log') ) {
-        s = str_remove(f, '.bbduk.log')
-        bbduk <- bbduk %>%
-            union(
-                read_tsv(
-                    pipe(sprintf("grep 'Result:' %s | sed 's/Result:[ \t]*//; s/ reads.*//' | sed 's/:/\t/'", f)),
-                    col_names = c('n_non_contaminated'),
-                    col_types = 'i'
-                ) %>%
-                    mutate(sample = s)
-            )
+        s <- str_remove(f, '.bbduk.log')
+        line <- grep('Result:', readLines(f), value = TRUE)
+        n <- as.integer(sub(' reads.*', '', sub('Result:[[:space:]]*', '', line)))
+        bbduk <- bbduk %>% union(tibble(n_non_contaminated = n, sample = s))
     }
     if ( nrow(bbduk) == 0 ) bbduk <- bbduk %>% select(sample)
 

--- a/modules/local/collect/stats/main.nf
+++ b/modules/local/collect/stats/main.nf
@@ -68,6 +68,25 @@ process COLLECT_STATS {
     """
     #!/usr/bin/env Rscript
 
+    # All read counts joined into this table (n_post_trimming, n_non_contaminated,
+    # idxs_n_mapped/idxs_n_unmapped, and the featureCounts columns) use the same unit:
+    # individual reads, with both mates of a pair counted separately -- none of them
+    # count fragments/pairs as a single unit, so the columns are directly comparable.
+    # Confirmed empirically for each source:
+    #   - n_post_trimming: Trim Galore's PE trimming report is per-mate-file, so only
+    #     the R1 report is read and multiplied by 2 (see 'mult' below) to reconstruct
+    #     the total across both mates.
+    #   - n_non_contaminated: BBDuk's "Result:" line already reports both mates combined.
+    #   - idxs_n_mapped/idxs_n_unmapped: samtools idxstats counts mapped read-segments,
+    #     i.e. each mate separately.
+    #   - featureCounts columns: SUBREAD_FEATURECOUNTS auto-adds '-p' for paired-end
+    #     samples (based on meta.single_end), but since '--countReadPairs' is NOT also
+    #     passed, Subread (2.0.3+) still counts at the individual-read level -- '-p'
+    #     alone only affects pairing validation, not the counted unit. Adding
+    #     '--countReadPairs' later (e.g. as a seemingly-modernizing change) would
+    #     silently switch this to fragment/pair counting and break comparability with
+    #     the other columns above.
+
     library(dplyr)
     library(readr)
     library(purrr)

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -371,7 +371,11 @@ workflow MAGMAP {
     //
     CREATE_BBMAP_INDEX.out.genome_accnos
         .collectFile(storeDir: "${outdir}/bbmap") { meta, accnos ->
-            [ "${meta.id}.genomes.txt", accnos.sort().join('\n') + '\n' ]
+            // sort(false) returns a new sorted list rather than sorting in place -- this
+            // same accnos list is also consumed (unsorted) by COLLECT_GENOMESELECTION
+            // below, and Groovy's no-arg List.sort() mutating it in place caused an
+            // intermittent ConcurrentModificationException there.
+            [ "${meta.id}.genomes.txt", accnos.sort(false).join('\n') + '\n' ]
         }
 
     //


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Two things bundled together, both touching the `summary_tables` generation code:

1. Documented (as a code comment in `COLLECT_STATS`) that all the read-count columns
   joined into `overall_stats.tsv.gz` (`n_post_trimming`, `n_non_contaminated`,
   `idxs_n_mapped`/`idxs_n_unmapped`, and the featureCounts columns) use the same unit —
   individual reads, with both mates of a pair counted separately — so they're directly
   comparable. Verified empirically against real Trim Galore/BBDuk/samtools
   idxstats/featureCounts output rather than just documentation. The featureCounts case
   is the non-obvious one: `SUBREAD_FEATURECOUNTS` auto-adds `-p` for paired-end samples,
   but without `--countReadPairs` it still counts at the individual-read level.

2. Fixes #218: `COLLECT_STATS`/`COLLECT_GENOMESELECTION` built R source by directly
   interpolating user-controlled values (sample IDs, genome accessions — documented as
   accepting arbitrary text via `--genomeinfo`) into single-quoted R string literals,
   which a value containing a quote could break (or worse). Also shelled out to
   grep/sed via `pipe(sprintf(...))` to parse trimming/BBDuk/idxstats files, passing
   sample-derived filenames through a shell command string, and hardcoded featureCounts'
   column layout as a positional type-code string instead of naming columns explicitly.
   Fixed all three.

Also includes a CI change: switched `nf-test` jobs from self-hosted to GitHub-hosted
(`ubuntu-latest`) runners, since the self-hosted runners have been getting stuck queued
(seen repeatedly on #219) — validated first on a smaller PR in nf-core/phyloplace.

The R-code fix was verified via a standalone Groovy escaping reproduction, and against
real featureCounts-derived counts files pulled from an actual test run's work directory
(same numbers as before the change). A full local `nf-test` run of the default profile
hit JVM heap exhaustion in `nf-test`'s own Java process partway through (unrelated to
this branch — this dev machine's local heap cap is marginal for the full test profile
under concurrency); CI, running on a clean dedicated runner, should confirm end-to-end.
