### PR TITLE
Document Prokka/Bakta version drift across a reused store dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Document that genomes reused from `--prokka_store_dir`/`--bakta_store_dir` across runs may have been annotated with different tool versions, not reflected in the collated `versions.yml`/MultiQC report ([#229](https://github.com/nf-core/magmap/issues/229), by @erikrikarddaniel).
 - [#223](https://github.com/nf-core/magmap/pull/223) - Keep the locally-reported Prokka version (`PROKKA_VERSION`) in sync with the vendored module's actual version, and reuse its container instead of a near-duplicate one (by @erikrikarddaniel).
 - [#222](https://github.com/nf-core/magmap/pull/222) - Fix brittle R code in `COLLECT_STATS`/`COLLECT_GENOMESELECTION` ([#218](https://github.com/nf-core/magmap/issues/218), by @erikrikarddaniel).
 - [#222](https://github.com/nf-core/magmap/pull/222) - Fix an intermittent `ConcurrentModificationException` in `COLLECT_GENOMESELECTION` caused by two channel subscribers sharing a mutable genome-accession list (by @erikrikarddaniel).

--- a/docs/output.md
+++ b/docs/output.md
@@ -140,6 +140,13 @@ The Bakta database itself is downloaded once into [`--bakta_db`](https://nf-co.r
 
 </details>
 
+:::warning
+`--prokka_store_dir`/`--bakta_store_dir` are reused across pipeline runs -- genomes already found there are skipped rather than re-annotated (see above).
+This means genomes accumulated in a store directory over time may have been annotated with _different_ versions of Prokka or Bakta, even though only a single, current version is reported in the collated `versions.yml`/MultiQC report.
+There is currently no automated check or report of per-genome annotation tool versions across a genome library (see [issue #229](https://github.com/nf-core/magmap/issues/229)).
+If consistent annotation-tool versions across your whole genome collection matters, either start from an empty store directory, or track outside the pipeline which version annotated which genome.
+:::
+
 ### Genome fetching
 
 When the pipeline is run with [`--skip_sourmash false`](https://nf-co.re/magmap/parameters/#skip_sourmash) and one or more index files passed to [`--indexes`](https://nf-co.re/magmap/parameters/#indexes), remote genomes will be identified and downloaded to the directory specified by [`--genome_store_dir`](https://nf-co.re/magmap/parameters/#genome_store_dir) (by default `genomes` in the working directory for the pipeline run).


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Documentation-only fix for #229, folded into the v1.2.0 release since it's low-risk and
was raised directly by the person reviewing the release PR. Genomes already present in
`--prokka_store_dir`/`--bakta_store_dir` are skipped rather than re-annotated on later
runs, so a genome library accumulated over time can end up annotated with a mix of
Prokka/Bakta versions -- not reflected in the collated `versions.yml`/MultiQC report,
which only shows the version used in the current run. Added a `:::warning` callout to
`docs/output.md` right after the Prokka/Bakta sections.

The heavier fix suggested in #229 (scan per-genome logs to report the actual version mix)
is deferred -- open question whether that's practical at genome-library scale (tens of
thousands of genomes).