### PR TITLE
Document the species_preference/multimapping relationship in usage docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -218,6 +218,8 @@ For `completeness`/`gtdb`, a genome missing completeness or contamination data i
 > [!NOTE]
 > To make sure you only get one genome per species, you need to make sure that your local database only contains one genome per species and use a remote Sourmash index with one genome per species.
 
+Keeping multiple genomes for the same species (the default, `all`) means reads from that species can map ambiguously across them -- see [Multimapping](#multimapping) below for how the pipeline handles that.
+
 ### Check duplicates
 
 The pipeline will perform validation checks to see if there are any duplicate names among the genomes that the user provides.
@@ -292,6 +294,11 @@ nextflow run nf-core/magmap -profile docker --outdir results/ --input samples.cs
 ```
 
 ### Multimapping
+
+A read can align equally well to more than one target sequence whenever the genome collection contains genomes similar enough that the read could plausibly have come from any of them.
+This happens most often when [`--species_preference`](#preferring-local-or-remote-genomes-for-the-same-species) is left at its default (`all`) and multiple genomes representing the same species are kept side by side; it can also happen across genomes of different species that happen to share conserved regions, regardless of `--species_preference`.
+Choosing a stricter `--species_preference` (`local`, `completeness` or `gtdb`) reduces multimapping by dropping redundant same-species genomes down to one representative, but that comes at the cost of losing whatever strain-level resolution the discarded genomes would have provided -- there's a direct tradeoff between "fewer ambiguous reads" and "keeping enough closely related genomes around to tell strains apart".
+If your downstream analysis cares about that resolution, prefer `--species_preference all` and rely on the settings below to control how the ambiguity itself is handled.
 
 If there are several possible alignments, BBMap align will, by default, assign a read to only one target sequence.
 The pipeline supports all four possible BBMap values for this option:


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Came up while discussing [#184](https://github.com/nf-core/magmap/issues/184) (adding inStrain): `docs/usage.md`'s existing "Multimapping" section documented *how* `--bbmap_ambiguous` works, but never explained *why* multimapping happens in the first place, or that it's a direct consequence of `--species_preference` keeping multiple similar genomes in the reference. The two sections weren't cross-linked at all.

This adds a short background paragraph at the top of "Multimapping" explaining the relationship and the tradeoff (fewer ambiguous reads vs. keeping enough closely related genomes to tell strains apart), plus a forward-pointer from the `species_preference` section. Docs-only, no code changes. Independent of the inStrain discussion itself -- that's a separate, bigger piece of work for later.
