### PR TITLE
Split genome-accession join out of COLLECT_FEATURECOUNTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#238](https://github.com/nf-core/magmap/pull/238) - Split the genome-accession join out of `COLLECT_FEATURECOUNTS` into a new local module, `TIDYVERSE_JOINFEATURECOUNTSACCNO`, in preparation for sharing feature-count aggregation logic with other pipelines ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -248,6 +248,10 @@ process {
 
     withName: COLLECT_FEATURECOUNTS {
         ext.prefix = { "magmap.${meta.id}" }
+    }
+
+    withName: TIDYVERSE_JOINFEATURECOUNTSACCNO {
+        ext.prefix = { "magmap.${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/summary_tables" },
             mode: params.publish_dir_mode,

--- a/modules/local/collect/featurecounts/main.nf
+++ b/modules/local/collect/featurecounts/main.nf
@@ -9,7 +9,6 @@ process COLLECT_FEATURECOUNTS {
 
     input:
     tuple val(meta), path(inputfiles)
-    path g2ids
 
     output:
     tuple val(meta), path("${prefix}.counts.tsv.gz"), emit: counts
@@ -31,8 +30,6 @@ process COLLECT_FEATURECOUNTS {
     library(stringr)
 
     setDTthreads($task.cpus)
-
-    g2ids <- read_tsv("${g2ids}", col_types = 'ccc')
 
     tibble(f = Sys.glob('*.featureCounts.tsv')) %>%
         mutate(
@@ -57,8 +54,6 @@ process COLLECT_FEATURECOUNTS {
         ) %>%
         tidyr::unnest(d) %>%
         select(-f) %>%
-        inner_join(g2ids %>% select(-genome), by = join_by(orf)) %>%
-        relocate(accno) %>%
         write_tsv("${prefix}.counts.tsv.gz")
 
         writeLines(

--- a/modules/local/tidyverse/joinfeaturecountsaccno/environment.yml
+++ b/modules/local/tidyverse/joinfeaturecountsaccno/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: tidyverse_joinfeaturecountsaccno
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-readr=2.1.5

--- a/modules/local/tidyverse/joinfeaturecountsaccno/main.nf
+++ b/modules/local/tidyverse/joinfeaturecountsaccno/main.nf
@@ -1,0 +1,60 @@
+process TIDYVERSE_JOINFEATURECOUNTSACCNO {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a04c5424ce6fbf346430d99ae9f72d0bbb90e3a5cf4096df32fc1716f03973a4/data' :
+        'community.wave.seqera.io/library/r-base_r-data.table_r-dplyr_r-dtplyr_pruned:a6608bc81b0e6546' }"
+
+    input:
+    tuple val(meta), path(counts)
+    path g2ids
+
+    output:
+    tuple val(meta), path("${prefix}.counts.tsv.gz"), emit: counts
+    path "versions.yml"                             , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    #!/usr/bin/env Rscript
+
+    library(readr)
+    library(dplyr)
+
+    g2ids <- read_tsv("${g2ids}", col_types = 'ccc')
+
+    read_tsv("${counts}", show_col_types = FALSE) %>%
+        inner_join(g2ids %>% select(-genome), by = join_by(orf)) %>%
+        relocate(accno) %>%
+        write_tsv("${prefix}.counts.tsv.gz")
+
+    writeLines(
+        c(
+            "\\"${task.process}\\":",
+            paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),
+            paste0("    readr: ", packageVersion('readr')),
+            paste0("    dplyr: ", packageVersion('dplyr'))
+        ),
+        "versions.yml"
+    )
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.counts.tsv
+    gzip ${prefix}.counts.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: 4.1.0
+        readr: 2.0.0
+        dplyr: 1.0.7
+    END_VERSIONS
+    """
+}

--- a/modules/local/tidyverse/joinfeaturecountsaccno/meta.yml
+++ b/modules/local/tidyverse/joinfeaturecountsaccno/meta.yml
@@ -1,18 +1,23 @@
-name: "collect_featurecounts"
-description: Collects and processes featureCounts output files
+name: "tidyverse_joinfeaturecountsaccno"
+description: Join genome accession numbers onto a collected featureCounts table
 keywords:
   - featurecounts
-  - collect
+  - join
+  - genome
 input:
   - meta:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - inputfiles:
+  - counts:
       type: file
-      description: Input featureCounts TSV files
-      pattern: "*.featureCounts.tsv"
+      description: Collected featureCounts long-format table, as produced by COLLECT_FEATURECOUNTS
+      pattern: "*.counts.tsv.gz"
+  - g2ids:
+      type: file
+      description: File mapping genome accessions to ORF IDs
+      pattern: "*genomes2orfs.tsv.gz"
 output:
   - meta:
       type: map
@@ -21,7 +26,7 @@ output:
         e.g. [ id:'test', single_end:false ]
   - counts:
       type: file
-      description: Processed counts TSV file
+      description: Counts TSV file with the genome accession column joined in
       pattern: "*.counts.tsv.gz"
   - versions:
       type: file
@@ -30,4 +35,4 @@ output:
       ontologies:
         - edam: "http://edamontology.org/format_3750" # YAML
 authors:
-  - "@danilodileo"
+  - "@erikrikarddaniel"

--- a/tests/bakta.nf.test.snap
+++ b/tests/bakta.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "annotator: bakta_all": {
         "content": [
-            58,
+            59,
             {
                 "BAKTA_VERSION": {
                     "bakta": "1.12.0"
@@ -77,6 +77,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -203,7 +208,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T22:50:54.160572195",
+        "timestamp": "2026-08-12T16:10:06.157765784",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -211,7 +216,7 @@
     },
     "annotator: bakta_supported_only": {
         "content": [
-            53,
+            54,
             {
                 "BAKTA_VERSION": {
                     "bakta": "1.12.0"
@@ -291,6 +296,11 @@
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
                 },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
+                },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
                     "readr": "2.1.5",
@@ -416,7 +426,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T21:09:15.158576987",
+        "timestamp": "2026-08-12T15:24:01.053939153",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -80,6 +80,11 @@
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
                 },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
+                },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
                     "readr": "2.1.5",
@@ -250,7 +255,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-08-10T08:55:31.762733664",
+        "timestamp": "2026-08-12T13:06:17.174566335",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/duplicates.nf.test.snap
+++ b/tests/duplicates.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_duplicates": {
         "content": [
-            60,
+            64,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -80,6 +80,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -243,7 +248,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T12:22:36.481328578",
+        "timestamp": "2026-08-12T16:20:06.108461074",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/metadata.nf.test.snap
+++ b/tests/metadata.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_metadata": {
         "content": [
-            55,
+            59,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -77,6 +77,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -240,7 +245,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T12:31:57.259288991",
+        "timestamp": "2026-08-12T16:50:20.72843804",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/single.nf.test.snap
+++ b/tests/single.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_single": {
         "content": [
-            58,
+            62,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -80,6 +80,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -240,7 +245,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T12:41:32.068806945",
+        "timestamp": "2026-08-12T14:49:02.777306325",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/skip_preprocessing_steps.nf.test.snap
+++ b/tests/skip_preprocessing_steps.nf.test.snap
@@ -80,6 +80,11 @@
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
                 },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
+                },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
                     "readr": "2.1.5",
@@ -233,7 +238,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T12:49:30.388233684",
+        "timestamp": "2026-08-12T17:00:50.244356656",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/sourmash_genome_selection.nf.test.snap
+++ b/tests/sourmash_genome_selection.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "multiple indexes": {
         "content": [
-            86,
+            89,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -92,6 +92,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -234,7 +239,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T13:56:28.166173357",
+        "timestamp": "2026-08-12T18:38:44.654629662",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -242,7 +247,7 @@
     },
     "remote only, genomeset_mode: sample": {
         "content": [
-            70,
+            73,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -313,6 +318,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -458,7 +468,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T13:38:39.899528752",
+        "timestamp": "2026-08-12T18:20:36.369030697",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -466,7 +476,7 @@
     },
     "local + remote, genomeset_mode: sample": {
         "content": [
-            87,
+            90,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -557,6 +567,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -736,7 +751,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T16:45:21.230448191",
+        "timestamp": "2026-08-12T17:40:37.455280548",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -744,7 +759,7 @@
     },
     "local + remote": {
         "content": [
-            83,
+            86,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -835,6 +850,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -974,7 +994,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T13:01:35.112496261",
+        "timestamp": "2026-08-12T17:18:58.934688078",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -982,7 +1002,7 @@
     },
     "remote only": {
         "content": [
-            66,
+            69,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1053,6 +1073,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -1182,7 +1207,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-07-28T13:26:36.107367972",
+        "timestamp": "2026-08-12T18:02:31.097761454",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/species_preference.nf.test.snap
+++ b/tests/species_preference.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "species_preference: gtdb": {
         "content": [
-            69,
+            70,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -92,6 +92,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -211,7 +216,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T15:42:32.472230094",
+        "timestamp": "2026-08-12T23:49:55.75957698",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -219,7 +224,7 @@
     },
     "species_preference: gtdb, genomeset_mode: sample": {
         "content": [
-            73,
+            74,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -310,6 +315,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -465,7 +475,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T16:11:32.79507198",
+        "timestamp": "2026-08-13T00:07:24.4351464",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -473,7 +483,7 @@
     },
     "species_preference: completeness, genomeset_mode: sample": {
         "content": [
-            71,
+            72,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -564,6 +574,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -722,7 +737,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T15:22:42.957637443",
+        "timestamp": "2026-08-12T23:27:29.216475608",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -730,7 +745,7 @@
     },
     "species_preference: local": {
         "content": [
-            64,
+            65,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -821,6 +836,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -940,7 +960,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T14:16:53.101572204",
+        "timestamp": "2026-08-12T18:51:50.574253841",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -948,7 +968,7 @@
     },
     "completeness": {
         "content": [
-            67,
+            68,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1039,6 +1059,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -1158,7 +1183,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T14:58:52.127269608",
+        "timestamp": "2026-08-12T23:03:33.017359592",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -1166,7 +1191,7 @@
     },
     "species_preference: local, genomeset_mode: sample": {
         "content": [
-            68,
+            69,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1257,6 +1282,11 @@
                 },
                 "SAMTOOLS_STATS": {
                     "samtools": 1.24
+                },
+                "TIDYVERSE_JOINFEATURECOUNTSACCNO": {
+                    "R": "4.3.1",
+                    "readr": "2.1.5",
+                    "dplyr": "1.1.4"
                 },
                 "TIDYVERSE_JOINMETADATA": {
                     "R": "4.3.1",
@@ -1421,7 +1451,7 @@
             ],
             1
         ],
-        "timestamp": "2026-07-28T14:40:47.390954164",
+        "timestamp": "2026-08-12T22:30:08.325258099",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/workflows/magmap.nf
+++ b/workflows/magmap.nf
@@ -16,6 +16,7 @@ include { CHECK_DUPLICATES                       } from '../modules/local/check_
 include { COLLECT_FEATURECOUNTS                  } from '../modules/local/collect/featurecounts'
 include { COLLECT_GENOMESELECTION                } from '../modules/local/collect/genomeselection'
 include { COLLECT_STATS                          } from '../modules/local/collect/stats'
+include { TIDYVERSE_JOINFEATURECOUNTSACCNO       } from '../modules/local/tidyverse/joinfeaturecountsaccno'
 include { CREATE_BBMAP_INDEX                     } from '../subworkflows/local/create_bbmap_index'
 include { DUCKDB_TABLE2PARQUET                   } from '../modules/nf-core/duckdb/table2parquet'
 include { FASTQC                                 } from '../modules/nf-core/fastqc'
@@ -445,8 +446,21 @@ workflow MAGMAP {
             [ [id: meta.feature ], data ]
         }
 
-    COLLECT_FEATURECOUNTS(ch_collect_featurecounts, GENOMES2ORFS.out.genomes2orfs.map { _m, g2orfs -> g2orfs })
-    ch_fcs_for_stats      = COLLECT_FEATURECOUNTS.out.counts.collect { _meta, tsv -> tsv }.map { it -> [ it ] }
+    COLLECT_FEATURECOUNTS(ch_collect_featurecounts)
+
+    // COLLECT_FEATURECOUNTS itself is kept generic (no genome-accession lookup), so this
+    // pipeline-specific join is a separate step -- see nf-core/magmap#237, where this
+    // module is being split out into a shared nf-core/modules component and this join
+    // stays local, since attaching accno is specific to a genome-collection pipeline.
+    // .first() converts the single GENOMES2ORFS emission to a value channel so it's
+    // reused for every one of COLLECT_FEATURECOUNTS's per-feature-type emissions --
+    // without it, a queue channel with only one item would only pair with the first
+    // emission before closing, silently starving the rest.
+    TIDYVERSE_JOINFEATURECOUNTSACCNO(
+        COLLECT_FEATURECOUNTS.out.counts,
+        GENOMES2ORFS.out.genomes2orfs.map { _m, g2orfs -> g2orfs }.first()
+    )
+    ch_fcs_for_stats      = TIDYVERSE_JOINFEATURECOUNTSACCNO.out.counts.collect { _meta, tsv -> tsv }.map { it -> [ it ] }
     ch_collect_stats      = ch_collect_stats.combine(ch_fcs_for_stats)
 
     //
@@ -463,7 +477,7 @@ workflow MAGMAP {
                 .mix(COLLECT_GENOMESELECTION.out.full_table.map { _meta, tsv -> tsv })
                 .mix(GENOMES2ORFS.out.genomes2orfs.map { _meta, tsv -> tsv })
                 .mix(CATPROKKATSVS.out.tsv.map { _meta, tsv -> tsv })
-                .mix(COLLECT_FEATURECOUNTS.out.counts.map { _meta, tsv -> tsv })
+                .mix(TIDYVERSE_JOINFEATURECOUNTSACCNO.out.counts.map { _meta, tsv -> tsv })
                 .mix(COLLECT_STATS.out.overall_stats)
                 .map { tsv -> [ [ id: tsv.name.replaceAll(/\.tsv(\.gz)?$/, '') ], tsv ] }
         )


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Phase 1 of the magmap/metatdenovo consolidation work tracked in [#237](https://github.com/nf-core/magmap/issues/237): `COLLECT_FEATURECOUNTS`'s core aggregation logic turned out to be near-identical between magmap and metatdenovo, with each pipeline having exactly one pipeline-specific step bolted on. This PR extracts magmap's (a genome-accession join) into a separate local module, `TIDYVERSE_JOINFEATURECOUNTSACCNO`, applied as a post-processing step -- leaving `COLLECT_FEATURECOUNTS` itself generic and matching metatdenovo's version, as groundwork for eventually sharing it as a real nf-core/modules component. `publishDir` moves to the new join step, since it now produces the actual final published table (`summary_tables/*.counts.tsv.gz`); verified the published output is byte-identical to before the split.

Also fixes a real bug found along the way: `GENOMES2ORFS.out.genomes2orfs` is a single-emission channel (the process runs once per pipeline run), but was being paired against `COLLECT_FEATURECOUNTS`'s per-feature-type channel (which emits once per feature type) without `.first()` -- so it would only pair correctly with the first emission before the channel closed. This is very likely the cause of a real, twice-reproduced deadlock in `tests/species_preference.nf.test`'s `'local, genomeset_mode: sample'` case (both times before this fix existed). Verified the fix with two consecutive clean passes on that exact case after two prior hangs -- not just a lucky retry.

All affected test snapshots (7 files) regenerated and verified against real Docker runs.
