### PR TITLE
Document why BBMap is used for read mapping instead of Bowtie2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#NN](https://github.com/nf-core/magmap/pull/NN) - Document why BBMap, rather than e.g. Bowtie2, is used for read mapping in `conf/modules.config` (by @erikrikarddaniel).
+- [#243](https://github.com/nf-core/magmap/pull/243) - Document why BBMap, rather than e.g. Bowtie2, is used for read mapping in `conf/modules.config` (by @erikrikarddaniel).
 - [#242](https://github.com/nf-core/magmap/pull/242) - Replace the local `COLLECT_STATS` module with the shared `nf-core/modules` component `custom/collectstats` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 - [#238](https://github.com/nf-core/magmap/pull/238) - Split the genome-accession join out of `COLLECT_FEATURECOUNTS` into a new local module, `TIDYVERSE_JOINFEATURECOUNTSACCNO`, in preparation for sharing feature-count aggregation logic with other pipelines ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Document why BBMap, rather than e.g. Bowtie2, is used for read mapping in `conf/modules.config` (by @erikrikarddaniel).
 - [#242](https://github.com/nf-core/magmap/pull/242) - Replace the local `COLLECT_STATS` module with the shared `nf-core/modules` component `custom/collectstats` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 - [#238](https://github.com/nf-core/magmap/pull/238) - Split the genome-accession join out of `COLLECT_FEATURECOUNTS` into a new local module, `TIDYVERSE_JOINFEATURECOUNTSACCNO`, in preparation for sharing feature-count aggregation logic with other pipelines ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -173,6 +173,14 @@ process {
         ]
     }
 
+    // BBMap (rather than e.g. Bowtie2, more commonly seen in other nf-core pipelines) maps
+    // reads to the combined index above, built from every genome in the collection. Bushnell's
+    // benchmark (BBMap: A Fast, Accurate, Splice-Aware Aligner, LBNL-7065E, 2014,
+    // https://www.osti.gov/biblio/1241166) found that Bowtie2 "failed to index the soil
+    // metagenome, so it cannot be recommended for metagenomics" -- a large, multi-genome
+    // reference is exactly this pipeline's index. BBMap's `ambig=` option below also gives
+    // explicit control over how reads multi-mapping across conserved regions shared by
+    // different genomes get resolved, which Bowtie2 does not expose in the same way.
     withName: BBMAP_ALIGN {
         label = "process_high_memory"
         ext.prefix = { "${meta.id}" }


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

BBMap (rather than e.g. Bowtie2) was originally chosen for read mapping in this pipeline on a hunch, never formally verified. Documents why it holds up, citing Bushnell's BBMap benchmark (LBNL-7065E, 2014, https://www.osti.gov/biblio/1241166), which found that Bowtie2 "failed to index the soil metagenome, so it cannot be recommended for metagenomics" -- directly relevant since this pipeline builds one combined BBMap index across every genome in the collection. Also notes that BBMap's `ambig=` option (already used via `--bbmap_ambiguous`) gives explicit control over multi-mapping reads across conserved regions shared by related genomes, which Bowtie2 doesn't expose in the same way.

Docs-only change, no functional/behavioral change. A companion note is planned for nf-core/metatdenovo, which uses BBMap the same way (mapping + contaminant removal), but that repo currently has other PRs open so it'll queue behind those.

Generated with the help of Claude Code.
