### PR TITLE
Skip NCBI genome catalog rows with a missing ftp_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Stop the pipeline crashing on any run when NCBI's live remote genome catalog contains a suppressed/replaced assembly with a missing `ftp_path` field; such genomes are now skipped instead, closes [#244](https://github.com/nf-core/magmap/issues/244) (by @erikrikarddaniel).
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/subworkflows/local/sourmash/main.nf
+++ b/subworkflows/local/sourmash/main.nf
@@ -27,6 +27,10 @@ workflow SOURMASH {
     main:
         ch_ncbi_genomeinfo = ch_remote_genome_sources
                 .splitCsv(skip: 1, header: true, sep: '\t')
+                // NCBI marks some suppressed/replaced assemblies in the live assembly_summary
+                // catalogs with an empty ftp_path -- such a genome can never be fetched anyway,
+                // so drop it here rather than crash the whole run on a null-safe string op below.
+                .filter { row -> row.ftp_path }
                 .map { row ->
                     [
                         accno: row["#assembly_accession"],


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

`SOURMASH`'s `ch_ncbi_genomeinfo` channel parses NCBI's live `assembly_summary_refseq.txt`/`assembly_summary_genbank.txt` catalogs unconditionally on every pipeline run (this channel-building `.map` isn't gated by `--indexes`/`--skip_sourmash` -- an unsubscribed Nextflow channel still executes its upstream operators eagerly). NCBI marks some suppressed/replaced assemblies in these catalogs with a missing `ftp_path` field, and `row.ftp_path - ~/\/$/` isn't null-safe, so hitting one throws a `NullPointerException` and aborts the whole run.

This is a **race**, not a deterministic per-profile failure: whichever finishes first -- the rest of the pipeline, or the background parse of the ~250k-row live catalog reaching the bad row -- decides whether a given run's session aborts before `workflow.success` gets recorded. That's why some test profiles showed this and others didn't in the same nf-test run: it's timing/network-speed dependent, not tied to specific pipeline logic. It could hit any CI run non-deterministically.

Such a genome can never be fetched anyway (there's no path to download it from), so it's now filtered out instead of crashing the run.

Verified with a minimal standalone Nextflow reproduction (confirmed the crash on unfixed code, and its absence after the fix, using a fixture row genuinely missing its trailing column to match NCBI's real data shape) before touching the real subworkflow.

Closes #244.

Generated with the help of Claude Code.
