### PR TITLE
Reduce sourmash_genome_selection/species_preference test data from 7 to 3 species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [#NN](https://github.com/nf-core/magmap/pull/NN) - Reduce the `sourmash_genome_selection`/`species_preference` nf-test data from 7 to 3 archaeal species, cutting per-scenario Prokka annotation load and CI runtime, closes [#246](https://github.com/nf-core/magmap/issues/246) (by @erikrikarddaniel).
+- [#250](https://github.com/nf-core/magmap/pull/250) - Reduce the `sourmash_genome_selection`/`species_preference` nf-test data from 7 to 3 archaeal species, cutting per-scenario Prokka annotation load and CI runtime, closes [#246](https://github.com/nf-core/magmap/issues/246) (by @erikrikarddaniel).
 - [#248](https://github.com/nf-core/magmap/pull/248) - Replace the local `COLLECT_FEATURECOUNTS` module with the shared `nf-core/modules` component `custom/collectfeaturecounts` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 - [#243](https://github.com/nf-core/magmap/pull/243) - Document why BBMap, rather than e.g. Bowtie2, is used for read mapping in `conf/modules.config` (by @erikrikarddaniel).
 - [#242](https://github.com/nf-core/magmap/pull/242) - Replace the local `COLLECT_STATS` module with the shared `nf-core/modules` component `custom/collectstats` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#NN](https://github.com/nf-core/magmap/pull/NN) - Reduce the `sourmash_genome_selection`/`species_preference` nf-test data from 7 to 3 archaeal species, cutting per-scenario Prokka annotation load and CI runtime, closes [#246](https://github.com/nf-core/magmap/issues/246) (by @erikrikarddaniel).
 - [#248](https://github.com/nf-core/magmap/pull/248) - Replace the local `COLLECT_FEATURECOUNTS` module with the shared `nf-core/modules` component `custom/collectfeaturecounts` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).
 - [#243](https://github.com/nf-core/magmap/pull/243) - Document why BBMap, rather than e.g. Bowtie2, is used for read mapping in `conf/modules.config` (by @erikrikarddaniel).
 - [#242](https://github.com/nf-core/magmap/pull/242) - Replace the local `COLLECT_STATS` module with the shared `nf-core/modules` component `custom/collectstats` ([#237](https://github.com/nf-core/magmap/issues/237), by @erikrikarddaniel).

--- a/conf/test_sourmash_genome_selection.config
+++ b/conf/test_sourmash_genome_selection.config
@@ -28,19 +28,19 @@ process {
 
 params {
     config_profile_name        = 'Test profile for Sourmash-driven genome selection'
-    config_profile_description = 'Minimal test dataset (archaeal genomes with duplicated species) to check Sourmash genome selection: all genomes kept, remote-only, and multiple index files'
+    config_profile_description = 'Minimal test dataset (3 archaeal species with duplicated genomes) to check Sourmash genome selection: all genomes kept, remote-only, and multiple index files'
 
     // Input data
-    input               = params.pipelines_testdata_base_path + 'magmap/samplesheets/archaeal_duplicate_genomes_per_species.csv'
-    indexes             = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.index.sbt.zip'
-    genomeinfo          = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.genomes.csv'
+    input               = params.pipelines_testdata_base_path + 'magmap/samplesheets/archaeal_trio_genomes_per_species.csv'
+    indexes             = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.index.sbt.zip'
+    genomeinfo          = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.genomes.csv'
     sourmash_ksize      = 31
     // Excludes tmRNA: Prokka finds none in this dataset, and featureCounts treats "no
     // features of this type" as a fatal error rather than returning zero counts.
     features            = 'CDS,rRNA,tRNA'
     gtdb_metadata       = "https://data.gtdb.ecogenomic.org/releases/release226/226.0/ar53_metadata_r226.tsv.gz"
-    checkm_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.checkm.tsv,' + params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.checkm2.tsv'
-    gtdbtk_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.gtdbtk.tsv'
+    checkm_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.checkm.tsv,' + params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.checkm2.tsv'
+    gtdbtk_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.gtdbtk.tsv'
 
     // Sourmash option
     skip_sourmash          = false

--- a/conf/test_species_preference.config
+++ b/conf/test_species_preference.config
@@ -26,17 +26,17 @@ process {
 
 params {
     config_profile_name        = 'Test profile for species_preference across genomeset_mode'
-    config_profile_description = 'Minimal test dataset (archaeal genomes with duplicated species) to check species_preference combined with genomeset_mode'
+    config_profile_description = 'Minimal test dataset (3 archaeal species with duplicated genomes) to check species_preference combined with genomeset_mode'
 
     // Input data
-    input               = params.pipelines_testdata_base_path + 'magmap/samplesheets/archaeal_duplicate_genomes_per_species.csv'
-    indexes             = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.index.sbt.zip'
-    genomeinfo          = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.genomes.csv'
+    input               = params.pipelines_testdata_base_path + 'magmap/samplesheets/archaeal_trio_genomes_per_species.csv'
+    indexes             = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.index.sbt.zip'
+    genomeinfo          = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.genomes.csv'
     sourmash_ksize      = 31
     features            = 'CDS'
     gtdb_metadata       = "https://data.gtdb.ecogenomic.org/releases/release226/226.0/ar53_metadata_r226.tsv.gz"
-    checkm_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.checkm.tsv,' + params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.checkm2.tsv'
-    gtdbtk_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_duplicates.gtdbtk.tsv'
+    checkm_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.checkm.tsv,' + params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.checkm2.tsv'
+    gtdbtk_metadata     = params.pipelines_testdata_base_path + 'magmap/testdata/archaeal_trio.gtdbtk.tsv'
     species_preference  = 'local'
 
     // Sourmash option

--- a/tests/sourmash_genome_selection.nf.test
+++ b/tests/sourmash_genome_selection.nf.test
@@ -32,11 +32,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
                 ).match() },
                 // 'all' keeps every local and every remote genome Sourmash matches -- no species dedup
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 6 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 14 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 10000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 45000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 22000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 2 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 6 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 8000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 15000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 8000 },
             )
         }
     }
@@ -69,11 +69,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.findAll { l -> l.contains('accno') },
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
                 ).match() },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 6 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 14 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 10000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 45000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 22000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 2 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 6 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 8000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 15000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 8000 },
             )
         }
     }
@@ -106,10 +106,10 @@ nextflow_pipeline {
                 ).match() },
                 // No --genomeinfo at all: every selected genome is remote, none of them local_*
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 8000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 25000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 12000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 10000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 5000 },
                 { assert path("${params.outdir}/sourmash/arc00_remoteidx_00_prefetch.csv.gz").linesGzip.size() > 0 },
             )
         }
@@ -146,9 +146,9 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('local_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 8000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 25000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 12000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 10000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 5000 },
                 { assert path("${params.outdir}/sourmash/arc00_remoteidx_00_prefetch.csv.gz").linesGzip.size() > 0 },
                 { assert path("${params.outdir}/sourmash/arc01_remoteidx_00_prefetch.csv.gz").linesGzip.size() > 0 },
                 { assert path("${params.outdir}/sourmash/arc02_remoteidx_00_prefetch.csv.gz").linesGzip.size() > 0 },
@@ -165,7 +165,7 @@ nextflow_pipeline {
                 // per-test override context (evaluates to null), so this has to be a
                 // literal URL rather than built from that param like the base config does.
                 // Keep in sync with pipelines_testdata_base_path in nextflow.config.
-                indexes = "https://raw.githubusercontent.com/nf-core/test-datasets/magmap/testdata/archaeal_duplicates.index.sbt.zip,https://raw.githubusercontent.com/nf-core/test-datasets/magmap/testdata/archaeal_duplicates.index.sbt.zip"
+                indexes = "https://raw.githubusercontent.com/nf-core/test-datasets/magmap/testdata/archaeal_trio.index.sbt.zip,https://raw.githubusercontent.com/nf-core/test-datasets/magmap/testdata/archaeal_trio.index.sbt.zip"
             }
         }
 
@@ -188,7 +188,7 @@ nextflow_pipeline {
                 ).match() },
                 // Same effective genome set as "all" -- two copies of the same index just proves
                 // comma-separated --indexes parsing and multi-index gathering doesn't break anything
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 14 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 6 },
                 { assert path("${params.outdir}/sourmash/arc00_remoteidx_00_prefetch.csv.gz").linesGzip.size() > 0 },
                 { assert path("${params.outdir}/sourmash/arc00_remoteidx_01_prefetch.csv.gz").linesGzip.size() > 0 },
             )

--- a/tests/sourmash_genome_selection.nf.test.snap
+++ b/tests/sourmash_genome_selection.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "multiple indexes": {
         "content": [
-            89,
+            73,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -211,18 +211,18 @@
                 "summary_tables/magmap.tRNA.counts.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,b944d7c3726a0454f18485d4b474eabb",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,490ddf3e5f47b0a3a6863f1fcfbf077c",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,26f79789c380394d13bb21521119e731"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,4982d7c0ecad450a22b0ef6ff6674db2"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA"
@@ -241,7 +241,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-09-01T21:55:24.980374594",
+        "timestamp": "2026-09-02T10:13:23.711711887",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -249,7 +249,7 @@
     },
     "remote only, genomeset_mode: sample": {
         "content": [
-            73,
+            65,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -428,20 +428,20 @@
                 "summary_tables/magmap.tRNA.counts.tsv.gz"
             ],
             [
-                "arc00.genomes.txt:md5,c21f8f8a718d32dc0f26874707b44b14",
-                "arc01.genomes.txt:md5,e6cf521da8f7114b10611272909824a0",
-                "arc02.genomes.txt:md5,18e6ec6dc8285f7a4e54a6ffc65438f7",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "arc00.genomes.txt:md5,f67f8647d336ef62f8d26dbe162a1fdd",
+                "arc01.genomes.txt:md5,a09e428c97fa6d6f3256c894becb3f39",
+                "arc02.genomes.txt:md5,dcb37b5a2d352f1276b952e93f269ffa",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,e55031ea22ff9ec8bccbd08aa1f69d48"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,3e9c9004b3067ba0cb71f8cd9b413ddd"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA"
@@ -453,13 +453,9 @@
             [
                 "GCF_000011125.1\tarc00",
                 "GCF_000011125.1\tarc01",
-                "GCF_000017945.1\tarc00",
-                "GCF_001412615.1\tarc01",
-                "GCF_003201675.2\tarc01",
-                "GCF_020886315.1\tarc02",
                 "GCF_022064045.1\tarc00",
                 "GCF_022064045.1\tarc02",
-                "GCF_030186535.1\tarc00",
+                "GCF_030186535.1\tarc01",
                 "GCF_030186535.1\tarc02"
             ],
             [
@@ -472,7 +468,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-09-01T21:23:44.60103208",
+        "timestamp": "2026-09-02T10:01:58.004289994",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -480,7 +476,7 @@
     },
     "local + remote, genomeset_mode: sample": {
         "content": [
-            90,
+            74,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -686,20 +682,20 @@
                 "summary_tables/magmap.tRNA.counts.tsv.gz"
             ],
             [
-                "arc00.genomes.txt:md5,7ae712916d80b7c61ad76205648ea941",
-                "arc01.genomes.txt:md5,f81d9b16b4ee1660f31a6ff1be9cc719",
-                "arc02.genomes.txt:md5,aac816c08252d5930371c490446076ec",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "arc00.genomes.txt:md5,2d20626da3e56e7f41c8ed13617781b3",
+                "arc01.genomes.txt:md5,775c4b1392064c7a55181061312b8dd7",
+                "arc02.genomes.txt:md5,db3be4a7930d51e5c636de7da06d600d",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,609f54644ac6fcae24358073fe13dc8b"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,8d48a2d118da88f40cb8b2be711290d9"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA"
@@ -711,37 +707,21 @@
             [
                 [
                     "GCF_000011125.1",
-                    "GCF_000017945.1",
                     "GCF_022064045.1",
-                    "GCF_030186535.1",
-                    "local_GCA_013329705.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ],
                 [
                     "GCF_000011125.1",
-                    "GCF_001412615.1",
-                    "GCF_003201675.2",
-                    "local_GCA_013329705.1",
+                    "GCF_030186535.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ],
                 [
-                    "GCF_020886315.1",
                     "GCF_022064045.1",
                     "GCF_030186535.1",
-                    "local_GCA_013329705.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ]
             ],
             [
@@ -757,7 +737,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-09-01T19:59:07.17714211",
+        "timestamp": "2026-09-02T08:30:35.302004215",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -765,7 +745,7 @@
     },
     "local + remote": {
         "content": [
-            86,
+            70,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -969,18 +949,18 @@
                 "summary_tables/magmap.tRNA.counts.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,b944d7c3726a0454f18485d4b474eabb",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,490ddf3e5f47b0a3a6863f1fcfbf077c",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,26f79789c380394d13bb21521119e731"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,4982d7c0ecad450a22b0ef6ff6674db2"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA"
@@ -1002,7 +982,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-09-01T19:19:17.187446067",
+        "timestamp": "2026-09-02T08:21:51.20602622",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -1010,7 +990,7 @@
     },
     "remote only": {
         "content": [
-            69,
+            61,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1187,18 +1167,18 @@
                 "summary_tables/magmap.tRNA.counts.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,757ada832145b9171f48929e7771e3dd",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,59212416cfaf722dad2e0fb30852298f",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,b3863dd38016f62360924a616ee79713"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,9c60cc58c7947ca4b3ea3ecdf576566c"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\ttRNA"
@@ -1217,7 +1197,7 @@
                 "orf\tftype\tlength\tgene\tec_number\tcog\tproduct"
             ]
         ],
-        "timestamp": "2026-09-01T20:48:35.693320585",
+        "timestamp": "2026-09-02T08:45:08.922781044",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/species_preference.nf.test
+++ b/tests/species_preference.nf.test
@@ -33,11 +33,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }
@@ -77,18 +77,18 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                // Genome selection is per-sample: arc00/arc02 pick up the remote genome GCF_022064045.1
-                // (its species has no local duplicate), arc01 doesn't -- confirms species_preference=local
-                // and genomeset_mode=sample correctly interact, rather than always falling back to a
-                // fully-local, identical-per-sample set.
-                { assert path("${params.outdir}/bbmap/arc00.genomes.txt").readLines().sort() == ['GCF_022064045.1', 'local_GCA_013329705.1', 'local_GCA_023269755.1', 'local_GCF_001315825.1', 'local_GCF_002194565.1', 'local_GCF_004323575.1', 'local_GCF_032248915.1'] },
-                { assert path("${params.outdir}/bbmap/arc01.genomes.txt").readLines().sort() == ['local_GCA_013329705.1', 'local_GCA_023269755.1', 'local_GCF_001315825.1', 'local_GCF_002194565.1', 'local_GCF_004323575.1', 'local_GCF_032248915.1'] },
-                { assert path("${params.outdir}/bbmap/arc02.genomes.txt").readLines().sort() == ['GCF_022064045.1', 'local_GCA_013329705.1', 'local_GCA_023269755.1', 'local_GCF_001315825.1', 'local_GCF_002194565.1', 'local_GCF_004323575.1', 'local_GCF_032248915.1'] },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                // Genome selection is per-sample: arc00/arc02 pick up the public genome GCF_022064045.1
+                // (Metallosphaera javensis has no local/user-provided duplicate), arc01 doesn't -- confirms
+                // species_preference=local and genomeset_mode=sample correctly interact, rather than always
+                // falling back to a fully-local, identical-per-sample set.
+                { assert path("${params.outdir}/bbmap/arc00.genomes.txt").readLines().sort() == ['GCF_022064045.1', 'local_GCA_023269755.1', 'local_GCF_004323575.1'] },
+                { assert path("${params.outdir}/bbmap/arc01.genomes.txt").readLines().sort() == ['local_GCA_023269755.1', 'local_GCF_004323575.1'] },
+                { assert path("${params.outdir}/bbmap/arc02.genomes.txt").readLines().sort() == ['GCF_022064045.1', 'local_GCA_023269755.1', 'local_GCF_004323575.1'] },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }
@@ -122,11 +122,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }
@@ -165,11 +165,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }
@@ -203,11 +203,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }
@@ -246,11 +246,11 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('\tgene\t') }.size(),
                 ).match() },
                 { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.findAll { l -> l.contains('^GC[AF]_') }.size() == 0 },
-                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 9000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 29000 },
-                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 8 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 14000 },
-                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 14000 },
+                { assert path("${params.outdir}/summary_tables/magmap.CDS.counts.tsv.gz").linesGzip.size() > 6000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genomes2orfs.tsv.gz").linesGzip.size() > 9000 },
+                { assert path("${params.outdir}/summary_tables/magmap.genome_metadata.tsv.gz").linesGzip.size() == 4 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.size() > 4000 },
+                { assert path("${params.outdir}/summary_tables/magmap.prokka-annotations.tsv.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 4000 },
             )
         }
     }

--- a/tests/species_preference.nf.test.snap
+++ b/tests/species_preference.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "species_preference: gtdb": {
         "content": [
-            70,
+            59,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -65,14 +65,6 @@
                 },
                 "GENOME_SKETCH": {
                     "sourmash": "4.9.4"
-                },
-                "PROKKAGFF2TSV": {
-                    "R": "4.3.1",
-                    "data.table": "1.17.8",
-                    "dtplyr": "1.3.2",
-                    "dplyr": "1.1.4",
-                    "tidyr": "1.3.1",
-                    "readr": "2.1.5"
                 },
                 "PROKKA_VERSION": {
                     "prokka": "1.15.6"
@@ -184,18 +176,18 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,a3a2b6592828c051bc342ee327702480",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,59212416cfaf722dad2e0fb30852298f",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,3e0ef1a47589d8793fa2ac563ca550b0"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,9c60cc58c7947ca4b3ea3ecdf576566c"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -218,7 +210,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-01T23:40:48.099399028",
+        "timestamp": "2026-09-02T11:16:02.596630397",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -226,7 +218,7 @@
     },
     "species_preference: gtdb, genomeset_mode: sample": {
         "content": [
-            74,
+            63,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -290,14 +282,6 @@
                 },
                 "GENOME_SKETCH": {
                     "sourmash": "4.9.4"
-                },
-                "PROKKAGFF2TSV": {
-                    "R": "4.3.1",
-                    "data.table": "1.17.8",
-                    "dtplyr": "1.3.2",
-                    "dplyr": "1.1.4",
-                    "tidyr": "1.3.1",
-                    "readr": "2.1.5"
                 },
                 "PROKKA_VERSION": {
                     "prokka": "1.15.6"
@@ -411,20 +395,20 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "arc00.genomes.txt:md5,bc0f6806d4c8c00ec43103bd6128530a",
-                "arc01.genomes.txt:md5,014cdf38cb0435a01e013f0931e5f6ba",
-                "arc02.genomes.txt:md5,36a2ef9ef2cae75d549a9bbafa715d56",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "arc00.genomes.txt:md5,f67f8647d336ef62f8d26dbe162a1fdd",
+                "arc01.genomes.txt:md5,a09e428c97fa6d6f3256c894becb3f39",
+                "arc02.genomes.txt:md5,dcb37b5a2d352f1276b952e93f269ffa",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,6a05091bd311300557b4629d1704ef5e"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,3e9c9004b3067ba0cb71f8cd9b413ddd"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -436,33 +420,23 @@
             [
                 "GCF_000011125.1\tarc00",
                 "GCF_000011125.1\tarc01",
-                "GCF_001412615.1\tarc01",
-                "GCF_003201675.2\tarc01",
-                "GCF_020886315.1\tarc02",
                 "GCF_022064045.1\tarc00",
                 "GCF_022064045.1\tarc02",
-                "GCF_030186535.1\tarc00",
-                "GCF_030186535.1\tarc02",
-                "local_GCA_013329705.1\tarc00"
+                "GCF_030186535.1\tarc01",
+                "GCF_030186535.1\tarc02"
             ],
             [
                 [
                     "GCF_000011125.1",
-                    "GCF_022064045.1",
-                    "GCF_030186535.1",
-                    "local_GCA_013329705.1"
+                    "GCF_022064045.1"
                 ],
                 [
                     "GCF_000011125.1",
-                    "GCF_001412615.1",
-                    "GCF_003201675.2",
-                    "local_GCA_013329705.1"
+                    "GCF_030186535.1"
                 ],
                 [
-                    "GCF_020886315.1",
                     "GCF_022064045.1",
-                    "GCF_030186535.1",
-                    "local_GCA_013329705.1"
+                    "GCF_030186535.1"
                 ]
             ],
             [
@@ -479,7 +453,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-01T23:52:52.698526763",
+        "timestamp": "2026-09-02T11:26:05.153086364",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -487,7 +461,7 @@
     },
     "species_preference: completeness, genomeset_mode: sample": {
         "content": [
-            72,
+            62,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -672,20 +646,20 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "arc00.genomes.txt:md5,41c5f54218e1b0d8084e0debfcabfce3",
-                "arc01.genomes.txt:md5,e73505cf4c71eaa34803d989916efc64",
-                "arc02.genomes.txt:md5,6c811e6039ae18bc71bfdd19df9bcc04",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "arc00.genomes.txt:md5,d43664f0f969e5778da44b4f6e7e7a89",
+                "arc01.genomes.txt:md5,81a840a694eacfeb21e04acfe66c03ef",
+                "arc02.genomes.txt:md5,919cc246c0db6ddc8f6e87bc7198cff3",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,f563ee06f07eec17664cdbe5824725fb"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,593916795e7f1d3c772f8fa2306ca9c3"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -695,37 +669,25 @@
                 "accno\torf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
             ],
             [
-                "GCF_003201675.2\tarc01",
-                "GCF_020886315.1\tarc02",
                 "GCF_022064045.1\tarc00",
                 "GCF_022064045.1\tarc02",
-                "GCF_030186535.1\tarc00",
+                "GCF_030186535.1\tarc01",
                 "GCF_030186535.1\tarc02",
-                "local_GCA_013329705.1\tarc00",
-                "local_GCF_002194565.1\tarc01",
                 "local_GCF_004323575.1\tarc00",
                 "local_GCF_004323575.1\tarc01"
             ],
             [
                 [
                     "GCF_022064045.1",
+                    "local_GCF_004323575.1"
+                ],
+                [
                     "GCF_030186535.1",
-                    "local_GCA_013329705.1",
-                    "local_GCF_002194565.1",
                     "local_GCF_004323575.1"
                 ],
                 [
-                    "GCF_003201675.2",
-                    "local_GCA_013329705.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1"
-                ],
-                [
-                    "GCF_020886315.1",
                     "GCF_022064045.1",
                     "GCF_030186535.1",
-                    "local_GCA_013329705.1",
-                    "local_GCF_002194565.1",
                     "local_GCF_004323575.1"
                 ]
             ],
@@ -743,7 +705,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-01T23:28:09.035307503",
+        "timestamp": "2026-09-02T11:02:38.115986305",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -751,7 +713,7 @@
     },
     "species_preference: local": {
         "content": [
-            65,
+            57,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -934,18 +896,18 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,2d550684976cd1372c8f7c67a3031250",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,671d0ddcbcab7f53dad15a0188b72710",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,be3a56db32288d8b35109b22e4aab512"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,363b85ce65173237c415607b7a791511"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -968,7 +930,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-01T22:26:17.679307993",
+        "timestamp": "2026-09-02T10:23:12.106860941",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -976,7 +938,7 @@
     },
     "completeness": {
         "content": [
-            68,
+            58,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1159,18 +1121,18 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "all.genomes.txt:md5,cc6ffa6ca3e12a69295163e0730715e7",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "all.genomes.txt:md5,919cc246c0db6ddc8f6e87bc7198cff3",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,2085697e5c22eaa9a67a245b57fc0a6b"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,96f8bcbd23f6b0055d7e04e9c8220e0e"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -1193,7 +1155,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-02T06:18:50.896532296",
+        "timestamp": "2026-09-02T10:46:36.241760522",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -1201,7 +1163,7 @@
     },
     "species_preference: local, genomeset_mode: sample": {
         "content": [
-            69,
+            61,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -1386,20 +1348,20 @@
                 "summary_tables/magmap.prokka-annotations.tsv.gz"
             ],
             [
-                "arc00.genomes.txt:md5,2d550684976cd1372c8f7c67a3031250",
-                "arc01.genomes.txt:md5,619047344c69ab98647e1eb902ad3c7b",
-                "arc02.genomes.txt:md5,2d550684976cd1372c8f7c67a3031250",
-                "fastqc-status-check-heatmap.txt:md5,24e97c0abe69381f1fbc50e2cdec3c33",
-                "fastqc_per_base_n_content_plot.txt:md5,d6eb0baa0dad9878d8531e3adb7892d7",
+                "arc00.genomes.txt:md5,671d0ddcbcab7f53dad15a0188b72710",
+                "arc01.genomes.txt:md5,75c151419492772a34fb5a46d162817f",
+                "arc02.genomes.txt:md5,671d0ddcbcab7f53dad15a0188b72710",
+                "fastqc-status-check-heatmap.txt:md5,2d048bc683af06a44639099eb03dd92a",
+                "fastqc_per_base_n_content_plot.txt:md5,644236c3a2aa8cac95222c0e60ae368d",
                 "fastqc_per_base_sequence_quality_plot.txt:md5,ef731079bd4eba01607a016cc40b4310",
-                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,973b41dfbd153f1ba706b01e38de2ca3",
-                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,b0848999c498a56adc3e02c4a5266ca1",
-                "fastqc_per_sequence_quality_scores_plot.txt:md5,dd3e11f739d9998714bb1b182de118aa",
-                "fastqc_sequence_counts_plot.txt:md5,db7a484b8cfc80e68dc7168244f32b51",
-                "fastqc_sequence_duplication_levels_plot.txt:md5,05b3b0febf818caf9fb99475c9a3a275",
+                "fastqc_per_sequence_gc_content_plot_Counts.txt:md5,e64e84094bab531e6a53e7ecd6a7fb31",
+                "fastqc_per_sequence_gc_content_plot_Percentages.txt:md5,ca048e37585c17fce2f3a6ff0aafd72f",
+                "fastqc_per_sequence_quality_scores_plot.txt:md5,34f453f7669f176b600b5d36e8a14c45",
+                "fastqc_sequence_counts_plot.txt:md5,fcc421ee837b2303f872145c66a4792f",
+                "fastqc_sequence_duplication_levels_plot.txt:md5,57427dfbeb25a085f516c1ee8c48e5d6",
                 "multiqc_citations.txt:md5,31ebda00f4c076224028ba5760113b5f",
-                "multiqc_fastqc.txt:md5,71d0889a7b479f12db53103470ee5ca5",
-                "multiqc_genome_selection.txt:md5,fcb9056516b99009a5cba74a198131b6"
+                "multiqc_fastqc.txt:md5,191ccf170e5f110119c395c54dae8845",
+                "multiqc_genome_selection.txt:md5,e01ac7cf3a1a5d6d922c88856fe6d184"
             ],
             [
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS"
@@ -1411,42 +1373,25 @@
             [
                 "GCF_022064045.1\tarc00",
                 "GCF_022064045.1\tarc02",
-                "local_GCA_013329705.1\tarc00",
-                "local_GCA_023269755.1\tarc00",
+                "local_GCA_023269755.1\tarc01",
                 "local_GCA_023269755.1\tarc02",
-                "local_GCF_001315825.1\tarc01",
-                "local_GCF_001315825.1\tarc02",
-                "local_GCF_002194565.1\tarc01",
                 "local_GCF_004323575.1\tarc00",
-                "local_GCF_004323575.1\tarc01",
-                "local_GCF_032248915.1\tarc02"
+                "local_GCF_004323575.1\tarc01"
             ],
             [
                 [
                     "GCF_022064045.1",
-                    "local_GCA_013329705.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ],
                 [
-                    "local_GCA_013329705.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ],
                 [
                     "GCF_022064045.1",
-                    "local_GCA_013329705.1",
                     "local_GCA_023269755.1",
-                    "local_GCF_001315825.1",
-                    "local_GCF_002194565.1",
-                    "local_GCF_004323575.1",
-                    "local_GCF_032248915.1"
+                    "local_GCF_004323575.1"
                 ]
             ],
             [
@@ -1463,7 +1408,7 @@
             ],
             1
         ],
-        "timestamp": "2026-09-01T22:52:52.262341672",
+        "timestamp": "2026-09-02T10:33:42.31209181",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
<!--
# nf-core/magmap pull request

Many thanks for contributing to nf-core/magmap!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/magmap/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/magmap _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #246: `sourmash_genome_selection.nf.test` and `species_preference.nf.test` were extremely slow because each selected genome without an existing GFF needs a full real Prokka annotation, and both used a fixture with 7 archaeal species / 14 genomes (7-8 genomes annotated per scenario).

Switches both to the new 3-species fixture added in nf-core/test-datasets#2256 (already merged). The 3 species were specifically chosen to preserve every `--species_preference` (local/completeness/gtdb) and `--genomeset_mode` (joint/sample) behaviour the original 7 exercised — see that PR's description/README for the full reasoning (CheckM/GTDB completeness numbers behind each choice).

Updated the hardcoded genome-count/size assertions and the exact `bbmap/*.genomes.txt` accession lists in both `.nf.test` files to match the new (smaller) fixture's real output; re-verified every scenario with real Docker `nf-test` runs.

**Runtime impact** (`sourmash_genome_selection.nf.test`, single-scenario wall time, real Docker runs, same machine):

| Scenario | Before | After |
| --- | --- | --- |
| local + remote | 1846s | 1026s |
| local + remote, sample | 2390s | 625s |
| remote only | 2969s | 452s |
| remote only, sample | 2109s | 535s |
| multiple indexes | 1900s | 686s |

`species_preference.nf.test`'s 6 scenarios saw a similar drop, each going from the
1800-2900s range down to roughly 500-1300s (Prokka annotating 1-3 genomes per
scenario instead of 6-8).

_Generated with some help from Claude Code._
